### PR TITLE
Refactors and addressed some issues.

### DIFF
--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{domainatrix}
-  s.version = "0.0.11"
+  s.version = "0.0.12"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Paul Dix"]

--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
     "spec/domainatrix_spec.rb",
     "spec/domainatrix/domain_parser_spec.rb",
     "spec/domainatrix/url_spec.rb"]
-  s.has_rdoc = true
   s.homepage = %q{http://github.com/pauldix/domainatrix}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.5}

--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{domainatrix}
-  s.version = "0.0.10"
+  s.version = "0.0.11"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Paul Dix"]

--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{domainatrix}
-  s.version = "0.0.9"
+  s.version = "0.0.10"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Paul Dix"]

--- a/lib/domainatrix.rb
+++ b/lib/domainatrix.rb
@@ -10,9 +10,13 @@ module Domainatrix
 
   def self.parse(url)
     Url.new(DOMAIN_PARSER.parse(url))
+  rescue ParseError
+    nil
   end
   
   def self.recognize_tld(tld)
     DOMAIN_PARSER.add_domain(tld)
   end
+  
+  class ParseError < StandardError; end
 end

--- a/lib/domainatrix.rb
+++ b/lib/domainatrix.rb
@@ -10,13 +10,9 @@ module Domainatrix
 
   def self.parse(url)
     Url.new(DOMAIN_PARSER.parse(url))
-  rescue ParseError
-    nil
   end
-  
+
   def self.recognize_tld(tld)
     DOMAIN_PARSER.add_domain(tld)
   end
-  
-  class ParseError < StandardError; end
 end

--- a/lib/domainatrix.rb
+++ b/lib/domainatrix.rb
@@ -11,4 +11,8 @@ module Domainatrix
   def self.parse(url)
     Url.new(DOMAIN_PARSER.parse(url))
   end
+  
+  def self.recognize_tld(tld)
+    DOMAIN_PARSER.add_domain(tld)
+  end
 end

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -58,11 +58,11 @@ module Domainatrix
       sub_hash = @public_suffixes
       public_suffix = []
 
-      parts.each_with_index do |part, i|
+      parts.each_with_index do |part, index|
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
         public_suffix << part
-        next_part = parts[i + 1]
+        next_part = parts[index + 1]
         if sub_parts.has_key? "*"
           public_suffix << next_part
           break

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -33,6 +33,7 @@ module Domainatrix
     end
 
     def parse(url)
+      url = "http://" + url unless url.match(/\/\//)
       begin
         uri = URI.parse(url)
       rescue Addressable::URI::InvalidURIError

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -1,7 +1,7 @@
 module Domainatrix
   class DomainParser
     include Addressable
-    
+
     attr_reader :public_suffixes
 
     def initialize(file_name)
@@ -16,7 +16,7 @@ module Domainatrix
       else
         dat_file = File.open(file_name)
       end
-      
+
       dat_file.each_line do |line|
         line = line.strip
         add_domain(line) unless (line =~ /\/\//) || line.empty?

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -55,20 +55,16 @@ module Domainatrix
       parts.each_with_index do |part, i|
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
-
+        public_suffix << part
         if sub_parts.has_key? "*"
-          public_suffix << part
           public_suffix << parts[i+1]
           domain = parts[i+2]
           subdomains = parts.slice(i+3, parts.size)
           break
         elsif sub_parts.empty? || !sub_parts.has_key?(parts[i+1])
-          public_suffix << part
           domain = parts[i+1]
           subdomains = parts.slice(i+2, parts.size)
           break
-        else
-          public_suffix << part
         end
       end
       {:public_suffix => public_suffix.reverse.join("."), :domain => domain, :subdomain => subdomains.reverse.join("."), :host => host}

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -52,9 +52,7 @@ module Domainatrix
       subdomains = []
       sub_hash = @public_suffixes
 
-      parts.each_index do |i|
-        part = parts[i]
-
+      parts.each_with_index do |part, i|
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
 

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -61,6 +61,7 @@ module Domainatrix
       parts.each_with_index do |part, index|
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
+        return "" unless sub_parts
         public_suffix << part
         next_part = parts[index + 1]
         if sub_parts.has_key? "*"

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -33,7 +33,11 @@ module Domainatrix
     end
 
     def parse(url)
-      uri = URI.parse(url)
+      begin
+        uri = URI.parse(url)
+      rescue Addressable::URI::InvalidURIError => e
+        return {}
+      end
       path = uri.path
       query = uri.query
       path += "?#{query}" if query
@@ -46,6 +50,9 @@ module Domainatrix
     end
 
     def parse_domains_from_host(host)
+      unless host
+        return {:public_suffix => "", :domain => "", :subdomain => "", :host => ""}
+      end
       public_suffix = parse_public_suffix_from_host(host)
       parts = host.gsub(public_suffix, '').split(".")
       domain = parts.pop

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -19,7 +19,7 @@ module Domainatrix
 
       dat_file.each_line do |line|
         line = line.strip
-        add_domain(line) unless (line =~ /\/\//) || line.empty?
+        add_domain(line) unless line.match(/\/\//)
       end
     end
 

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -34,6 +34,8 @@ module Domainatrix
 
     def parse(url)
       uri = URI.parse(url)
+      raise ParseError unless uri && !uri.host.nil?
+      
       if uri.query
         path = "#{uri.path}?#{uri.query}"
       else
@@ -58,6 +60,8 @@ module Domainatrix
 
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
+        raise ParseError if sub_hash.nil?
+        
         if sub_parts.has_key? "*"
           public_suffix << part
           public_suffix << parts[i+1]

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -35,7 +35,7 @@ module Domainatrix
     def parse(url)
       begin
         uri = URI.parse(url)
-      rescue Addressable::URI::InvalidURIError => e
+      rescue Addressable::URI::InvalidURIError
         return {}
       end
       path = uri.path

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -19,14 +19,16 @@ module Domainatrix
       
       dat_file.each_line do |line|
         line = line.strip
-        unless (line =~ /\/\//) || line.empty?
-          parts = line.split(".").reverse
+        add_domain(line) unless (line =~ /\/\//) || line.empty?
+      end
+    end
+    
+    def add_domain(name)
+      parts = name.split(".").reverse
 
-          sub_hash = @public_suffixes
-          parts.each do |part|
-            sub_hash = (sub_hash[part] ||= {})
-          end
-        end
+      sub_hash = @public_suffixes
+      parts.each do |part|
+        sub_hash = (sub_hash[part] ||= {})
       end
     end
 

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -43,7 +43,6 @@ module Domainatrix
       end
       parse_domains_from_host(uri.host).merge({
         :scheme => uri.scheme,
-        :host   => uri.host,
         :path   => path,
         :url    => url
       })
@@ -55,6 +54,7 @@ module Domainatrix
       domain = ""
       subdomains = []
       sub_hash = @public_suffixes
+
       parts.each_index do |i|
         part = parts[i]
 
@@ -77,7 +77,7 @@ module Domainatrix
           public_suffix << part
         end
       end
-      {:public_suffix => public_suffix.reverse.join("."), :domain => domain, :subdomain => subdomains.reverse.join(".")}
+      {:public_suffix => public_suffix.reverse.join("."), :domain => domain, :subdomain => subdomains.reverse.join("."), :host => host}
     end
   end
 end

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -22,7 +22,7 @@ module Domainatrix
         add_domain(line) unless (line =~ /\/\//) || line.empty?
       end
     end
-    
+
     def add_domain(name)
       parts = name.split(".").reverse
 
@@ -34,13 +34,9 @@ module Domainatrix
 
     def parse(url)
       uri = URI.parse(url)
-      raise ParseError unless uri && !uri.host.nil?
-      
-      if uri.query
-        path = "#{uri.path}?#{uri.query}"
-      else
-        path = uri.path
-      end
+      path = uri.path
+      path += "?#{uri.query}" if uri.query
+
       parse_domains_from_host(uri.host).merge({
         :scheme => uri.scheme,
         :path   => path,
@@ -60,8 +56,7 @@ module Domainatrix
 
         sub_parts = sub_hash[part]
         sub_hash = sub_parts
-        raise ParseError if sub_hash.nil?
-        
+
         if sub_parts.has_key? "*"
           public_suffix << part
           public_suffix << parts[i+1]

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -48,13 +48,9 @@ module Domainatrix
     def parse_domains_from_host(host)
       public_suffix = parse_public_suffix_from_host(host)
       parts = host.gsub(public_suffix, '').split(".")
-
-      domain = ""
-      subdomains = []
-
-      domain = parts.last
-      subdomains = parts.slice(0, parts.size - 1) if parts.length > 1
-      {:public_suffix => public_suffix, :domain => domain, :subdomain => subdomains.join("."), :host => host}
+      domain = parts.pop
+      subdomains = parts.join(".")
+      {:public_suffix => public_suffix, :domain => domain, :subdomain => subdomains, :host => host}
     end
 
     def parse_public_suffix_from_host(host)

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -35,7 +35,8 @@ module Domainatrix
     def parse(url)
       uri = URI.parse(url)
       path = uri.path
-      path += "?#{uri.query}" if uri.query
+      query = uri.query
+      path += "?#{query}" if query
 
       parse_domains_from_host(uri.host).merge({
         :scheme => uri.scheme,

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -29,5 +29,8 @@ module Domainatrix
     end
     alias domain_with_tld domain_with_public_suffix
 
+    def valid?
+      !@public_suffix.empty?
+    end
   end
 end

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -13,6 +13,7 @@ module Domainatrix
     end
 
     def canonical(options = {})
+      return nil unless valid?
       public_suffix_parts = @public_suffix.split(".")
       url = "#{public_suffix_parts.reverse.join(".")}.#{@domain}"
       if @subdomain && !@subdomain.empty?

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -30,7 +30,7 @@ module Domainatrix
     alias domain_with_tld domain_with_public_suffix
 
     def valid?
-      !@public_suffix.empty?
+      @public_suffix and !@public_suffix.empty?
     end
   end
 end

--- a/lib/effective_tld_names.dat
+++ b/lib/effective_tld_names.dat
@@ -1,3 +1,4 @@
+
 // ***** BEGIN LICENSE BLOCK *****
 // Version: MPL 1.1/GPL 2.0/LGPL 2.1
 // 
@@ -19,10 +20,11 @@
 // the Initial Developer. All Rights Reserved.
 // 
 // Contributor(s):
-//   Ruben Arakelyan <ruben@wackomenace.co.uk>
+//   Ruben Arakelyan <ruben@rubenarakelyan.com>
 //   Gervase Markham <gerv@gerv.net>
 //   Pamela Greene <pamg.bugs@gmail.com>
 //   David Triendl <david@triendl.name>
+//   Jothan Frakes <jothan@gmail.com>
 //   The kind representatives of many TLD registries
 // 
 // Alternatively, the contents of this file may be used under the terms of
@@ -38,7 +40,7 @@
 // the terms of any one of the MPL, the GPL or the LGPL.
 // 
 // ***** END LICENSE BLOCK *****
-
+ 
 // ac : http://en.wikipedia.org/wiki/.ac
 ac
 com.ac
@@ -47,11 +49,11 @@ gov.ac
 net.ac
 mil.ac
 org.ac
-
+ 
 // ad : http://en.wikipedia.org/wiki/.ad
 ad
 nom.ad
-
+ 
 // ae : http://en.wikipedia.org/wiki/.ae
 // see also: "Domain Name Eligibility Policy" at http://www.aeda.ae/eng/aepolicy.php
 ae
@@ -62,7 +64,7 @@ sch.ae
 ac.ae
 gov.ae
 mil.ae
-
+ 
 // aero : see http://www.information.aero/index.php?id=66
 aero
 accident-investigation.aero
@@ -154,7 +156,7 @@ trainer.aero
 union.aero
 workinggroup.aero
 works.aero
-
+ 
 // af : http://www.nic.af/help.jsp
 af
 gov.af
@@ -162,7 +164,7 @@ com.af
 org.af
 net.af
 edu.af
-
+ 
 // ag : http://www.nic.ag/prices.htm
 ag
 com.ag
@@ -170,32 +172,33 @@ org.ag
 net.ag
 co.ag
 nom.ag
-
+ 
 // ai : http://nic.com.ai/
 ai
 off.ai
 com.ai
 net.ai
 org.ai
-
-// al : http://www.inima.al/Domains.html
+ 
+// al : http://www.ert.gov.al/ert_alb/faq_det.html?Id=31
 al
-gov.al
-edu.al
-org.al
 com.al
+edu.al
+gov.al
+mil.al
 net.al
-
+org.al
+ 
 // am : http://en.wikipedia.org/wiki/.am
 am
-
+ 
 // an : http://www.una.an/an_domreg/default.asp
 an
 com.an
 net.an
 org.an
 edu.an
-
+ 
 // ao : http://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
 ao
@@ -205,10 +208,10 @@ og.ao
 co.ao
 pb.ao
 it.ao
-
+ 
 // aq : http://en.wikipedia.org/wiki/.aq
 aq
-
+ 
 // ar : http://en.wikipedia.org/wiki/.ar
 *.ar
 !congresodelalengua3.ar
@@ -220,34 +223,39 @@ aq
 !promocion.ar
 !retina.ar
 !uba.ar
-
+ 
 // arpa : http://en.wikipedia.org/wiki/.arpa
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 e164.arpa
 in-addr.arpa
 ip6.arpa
+iris.arpa
 uri.arpa
 urn.arpa
-
+ 
 // as : http://en.wikipedia.org/wiki/.as
 as
 gov.as
-
+ 
 // asia: http://en.wikipedia.org/wiki/.asia
 asia
-
+ 
 // at : http://en.wikipedia.org/wiki/.at
 // Confirmed by registry <it@nic.at> 2008-06-17
 at
-gv.at
 ac.at
 co.at
+gv.at
 or.at
-
+ 
+// http://www.info.at/
+biz.at
+info.at
+ 
 // priv.at : http://www.nic.priv.at/
 // Submitted by registry <lendl@nic.at> 2008-06-09
 priv.at
-
+ 
 // au : http://en.wikipedia.org/wiki/.au
 *.au
 // au geographical names (vic.au etc... are covered above)
@@ -260,21 +268,31 @@ tas.edu.au
 vic.edu.au
 wa.edu.au
 act.gov.au
-nsw.gov.au
+// Removed at request of Shae.Donelan@services.nsw.gov.au, 2010-03-04
+// nsw.gov.au
 nt.gov.au
 qld.gov.au
 sa.gov.au
 tas.gov.au
 vic.gov.au
 wa.gov.au
-
+// CGDNs - http://www.aucd.org.au/
+act.au
+nsw.au
+nt.au
+qld.au
+sa.au
+tas.au
+vic.au
+wa.au
+ 
 // aw : http://en.wikipedia.org/wiki/.aw
 aw
 com.aw
-
+ 
 // ax : http://en.wikipedia.org/wiki/.ax
 ax
-
+ 
 // az : http://en.wikipedia.org/wiki/.az
 az
 com.az
@@ -289,7 +307,7 @@ mil.az
 name.az
 pro.az
 biz.az
-
+ 
 // ba : http://en.wikipedia.org/wiki/.ba
 ba
 org.ba
@@ -302,27 +320,30 @@ unbi.ba
 co.ba
 com.ba
 rs.ba
-
+ 
 // bb : http://en.wikipedia.org/wiki/.bb
 bb
+biz.bb
 com.bb
 edu.bb
 gov.bb
+info.bb
 net.bb
 org.bb
-
+store.bb
+ 
 // bd : http://en.wikipedia.org/wiki/.bd
 *.bd
-
+ 
 // be : http://en.wikipedia.org/wiki/.be
 // Confirmed by registry <tech@dns.be> 2008-06-08
 be
 ac.be
-
+ 
 // bf : http://en.wikipedia.org/wiki/.bf
 bf
 gov.bf
-
+ 
 // bg : http://en.wikipedia.org/wiki/.bg
 // https://www.register.bg/user/static/rules/en/index.html
 bg
@@ -362,12 +383,15 @@ z.bg
 7.bg
 8.bg
 9.bg	 	 	
-
+ 
 // bh : http://en.wikipedia.org/wiki/.bh
-// list of other 2nd level tlds ?
 bh
 com.bh
-
+edu.bh
+net.bh
+org.bh
+gov.bh
+ 
 // bi : http://en.wikipedia.org/wiki/.bi
 // http://whois.nic.bi/
 bi
@@ -376,14 +400,16 @@ com.bi
 edu.bi
 or.bi
 org.bi
-
+ 
 // biz : http://en.wikipedia.org/wiki/.biz
 biz
-
+ 
 // bj : http://en.wikipedia.org/wiki/.bj
-// list of 2nd level tlds ?
 bj
-
+asso.bj
+barreau.bj
+gouv.bj
+ 
 // bm : http://www.bermudanic.bm/dnr-text.txt
 bm
 com.bm
@@ -391,10 +417,10 @@ edu.bm
 gov.bm
 net.bm
 org.bm
-
+ 
 // bn : http://en.wikipedia.org/wiki/.bn
 *.bn
-
+ 
 // bo : http://www.nic.bo/
 bo
 com.bo
@@ -406,10 +432,9 @@ org.bo
 net.bo
 mil.bo
 tv.bo
-
-// br : http://en.wikipedia.org/wiki/.br
-// http://registro.br/info/dpn.html
-// Confirmed by registry <fneves@registro.br> 2008-06-24
+ 
+// br : http://registro.br/dominio/dpn.html
+// Updated by registry <fneves@registro.br> 2011-03-01
 br
 adm.br
 adv.br
@@ -418,6 +443,7 @@ am.br
 arq.br
 art.br
 ato.br
+b.br
 bio.br
 blog.br
 bmd.br
@@ -429,6 +455,7 @@ com.br
 coop.br
 ecn.br
 edu.br
+emp.br
 eng.br
 esp.br
 etc.br
@@ -463,9 +490,12 @@ pro.br
 psc.br
 psi.br
 qsl.br
+radio.br
 rec.br
 slg.br
 srv.br
+taxi.br
+teo.br
 tmp.br
 trd.br
 tur.br
@@ -474,7 +504,7 @@ vet.br
 vlog.br
 wiki.br
 zlg.br
-
+ 
 // bs : http://www.nic.bs/rules.html
 bs
 com.bs
@@ -482,20 +512,25 @@ net.bs
 org.bs
 edu.bs
 gov.bs
-
+ 
 // bt : http://en.wikipedia.org/wiki/.bt
-*.bt
-
+bt
+com.bt
+edu.bt
+gov.bt
+net.bt
+org.bt
+ 
 // bv : No registrations at this time.
 // Submitted by registry <jarle@uninett.no> 2006-06-16
-
+ 
 // bw : http://en.wikipedia.org/wiki/.bw
 // http://www.gobin.info/domainname/bw.doc
 // list of other 2nd level tlds ?
 bw
 co.bw
 org.bw
-
+ 
 // by : http://en.wikipedia.org/wiki/.by
 // http://tld.by/rules_2006_en.html
 // list of other 2nd level tlds ?
@@ -506,7 +541,10 @@ mil.by
 // second-level domain, but it's being used as one (see www.google.com.by and
 // www.yahoo.com.by, for example), so we list it here for safety's sake.
 com.by
-
+ 
+// http://hoster.by/
+of.by
+ 
 // bz : http://en.wikipedia.org/wiki/.bz
 // http://www.belizenic.bz/
 bz
@@ -515,7 +553,7 @@ net.bz
 org.bz
 edu.bz
 gov.bz
-
+ 
 // ca : http://en.wikipedia.org/wiki/.ca
 ca
 // ca geographical names
@@ -536,27 +574,27 @@ yk.ca
 // gc.ca: http://en.wikipedia.org/wiki/.gc.ca
 // see also: http://registry.gc.ca/en/SubdomainFAQ
 gc.ca
-
+ 
 // cat : http://en.wikipedia.org/wiki/.cat
 cat
-
+ 
 // cc : http://en.wikipedia.org/wiki/.cc
 cc
-
+ 
 // cd : http://en.wikipedia.org/wiki/.cd
 // see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1
 cd
 gov.cd
-
+ 
 // cf : http://en.wikipedia.org/wiki/.cf
 cf
-
+ 
 // cg : http://en.wikipedia.org/wiki/.cg
 cg
-
+ 
 // ch : http://en.wikipedia.org/wiki/.ch
 ch
-
+ 
 // ci : http://en.wikipedia.org/wiki/.ci
 // http://www.nic.ci/index.php?page=charte
 ci
@@ -575,19 +613,19 @@ int.ci
 presse.ci
 md.ci
 gouv.ci
-
+ 
 // ck : http://en.wikipedia.org/wiki/.ck
 *.ck
-
+ 
 // cl : http://en.wikipedia.org/wiki/.cl
 cl
 gov.cl
 gob.cl
-
+ 
 // cm : http://en.wikipedia.org/wiki/.cm
 cm
 gov.cm
-
+ 
 // cn : http://en.wikipedia.org/wiki/.cn
 // Submitted by registry <tanyaling@cnnic.cn> 2008-06-11
 cn
@@ -636,7 +674,7 @@ zj.cn
 hk.cn
 mo.cn
 tw.cn
-
+ 
 // co : http://en.wikipedia.org/wiki/.co
 // Submitted by registry <tecnico@uniandes.edu.co> 2008-06-11
 co
@@ -653,10 +691,10 @@ nom.co
 org.co
 rec.co
 web.co
-
+ 
 // com : http://en.wikipedia.org/wiki/.com
 com
-
+ 
 // CentralNic names : http://www.centralnic.com/names/domains
 // Confirmed by registry <gavin.brown@centralnic.com> 2008-06-09
 ar.com
@@ -677,10 +715,16 @@ uk.com
 us.com
 uy.com
 za.com
-
+ 
+// Requested by Yngve Pettersen <yngve@opera.com> 2009-11-26
+operaunite.com
+ 
+// Requested by Eduardo Vela <evn@google.com> 2010-09-06
+appspot.com
+ 
 // coop : http://en.wikipedia.org/wiki/.coop
 coop
-
+ 
 // cr : http://www.nic.cr/niccr_publico/showRegistroDominiosScreen.do
 cr
 ac.cr
@@ -690,7 +734,7 @@ fi.cr
 go.cr
 or.cr
 sa.cr
-
+ 
 // cu : http://en.wikipedia.org/wiki/.cu
 cu
 com.cu
@@ -699,33 +743,33 @@ org.cu
 net.cu
 gov.cu
 inf.cu
-
+ 
 // cv : http://en.wikipedia.org/wiki/.cv
 cv
-
+ 
 // cx : http://en.wikipedia.org/wiki/.cx
 // list of other 2nd level tlds ?
 cx
 gov.cx
-
+ 
 // cy : http://en.wikipedia.org/wiki/.cy
 *.cy
-
+ 
 // cz : http://en.wikipedia.org/wiki/.cz
 cz
-
+ 
 // de : http://en.wikipedia.org/wiki/.de
 // Confirmed by registry <ops@denic.de> (with technical
 // reservations) 2008-07-01
 de
-
+ 
 // dj : http://en.wikipedia.org/wiki/.dj
 dj
-
+ 
 // dk : http://en.wikipedia.org/wiki/.dk
 // Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17
 dk
-
+ 
 // dm : http://en.wikipedia.org/wiki/.dm
 dm
 com.dm
@@ -733,10 +777,20 @@ net.dm
 org.dm
 edu.dm
 gov.dm
-
+ 
 // do : http://en.wikipedia.org/wiki/.do
-*.do
-
+do
+art.do
+com.do
+edu.do
+gob.do
+gov.do
+mil.do
+net.do
+org.do
+sld.do
+web.do
+ 
 // dz : http://en.wikipedia.org/wiki/.dz
 dz
 com.dz
@@ -747,7 +801,7 @@ edu.dz
 asso.dz
 pol.dz
 art.dz
-
+ 
 // ec : http://www.nic.ec/reg/paso1.asp
 // Submitted by registry <vabboud@nic.ec> 2008-07-04
 ec
@@ -761,11 +815,12 @@ pro.ec
 org.ec
 edu.ec
 gov.ec
+gob.ec
 mil.ec
-
+ 
 // edu : http://en.wikipedia.org/wiki/.edu
 edu
-
+ 
 // ee : http://www.eenet.ee/EENet/dom_reeglid.html#lisa_B
 ee
 edu.ee
@@ -778,13 +833,22 @@ pri.ee
 aip.ee
 org.ee
 fie.ee
-
+ 
 // eg : http://en.wikipedia.org/wiki/.eg
-*.eg
-
+eg  
+com.eg
+edu.eg
+eun.eg
+gov.eg
+mil.eg
+name.eg
+net.eg
+org.eg
+sci.eg
+ 
 // er : http://en.wikipedia.org/wiki/.er
 *.er
-
+ 
 // es : https://www.nic.es/site_ingles/ingles/dominios/index.html
 es
 com.es
@@ -792,13 +856,13 @@ nom.es
 org.es
 gob.es
 edu.es
-
+ 
 // et : http://en.wikipedia.org/wiki/.et
 *.et
-
+ 
 // eu : http://en.wikipedia.org/wiki/.eu
 eu
-
+ 
 // fi : http://en.wikipedia.org/wiki/.fi
 fi
 // aland.fi : http://en.wikipedia.org/wiki/.ax
@@ -807,19 +871,21 @@ fi
 // completely removed.
 // TODO: Check for updates (expected to be phased out around Q1/2009)
 aland.fi
-
+// iki.fi : Submitted by Hannu Aronsson <haa@iki.fi> 2009-11-05
+iki.fi
+ 
 // fj : http://en.wikipedia.org/wiki/.fj
 *.fj
-
+ 
 // fk : http://en.wikipedia.org/wiki/.fk
 *.fk
-
+ 
 // fm : http://en.wikipedia.org/wiki/.fm
 fm
-
+ 
 // fo : http://en.wikipedia.org/wiki/.fo
 fo
-
+ 
 // fr : http://www.afnic.fr/
 // domaines descriptifs : http://www.afnic.fr/obtenir/chartes/nommage-fr/annexe-descriptifs
 fr
@@ -847,16 +913,16 @@ notaires.fr
 pharmacien.fr
 port.fr
 veterinaire.fr
-
+ 
 // ga : http://en.wikipedia.org/wiki/.ga
 ga
-
+ 
 // gb : This registry is effectively dormant
 // Submitted by registry <Damien.Shaw@ja.net> 2008-06-12
-
+ 
 // gd : http://en.wikipedia.org/wiki/.gd
 gd
-
+ 
 // ge : http://www.nic.net.ge/policy_en.pdf
 ge
 com.ge
@@ -866,10 +932,10 @@ org.ge
 mil.ge
 net.ge
 pvt.ge
-
+ 
 // gf : http://en.wikipedia.org/wiki/.gf
 gf
-
+ 
 // gg : http://www.channelisles.net/applic/avextn.shtml
 gg
 co.gg
@@ -877,7 +943,7 @@ org.gg
 net.gg
 sch.gg
 gov.gg
-
+ 
 // gh : http://en.wikipedia.org/wiki/.gh
 // see also: http://www.nic.gh/reg_now.php
 // Although domains directly at second level are not possible at the moment,
@@ -888,7 +954,7 @@ edu.gh
 gov.gh
 org.gh
 mil.gh
-
+ 
 // gi : http://www.nic.gi/rules.html
 gi
 com.gi
@@ -897,13 +963,14 @@ gov.gi
 mod.gi
 edu.gi
 org.gi
-
+ 
 // gl : http://en.wikipedia.org/wiki/.gl
+// http://nic.gl
 gl
-
+ 
 // gm : http://www.nic.gm/htmlpages%5Cgm-policy.htm
 gm
-
+ 
 // gn : http://psg.com/dns/gn/gn.txt
 // Submitted by registry <randy@psg.com> 2008-06-17
 ac.gn
@@ -912,10 +979,10 @@ edu.gn
 gov.gn
 org.gn
 net.gn
-
+ 
 // gov : http://en.wikipedia.org/wiki/.gov
 gov
-
+ 
 // gp : http://www.nic.gp/index.php?lang=en
 gp
 com.gp
@@ -924,10 +991,10 @@ mobi.gp
 edu.gp
 org.gp
 asso.gp
-
+ 
 // gq : http://en.wikipedia.org/wiki/.gq
 gq
-
+ 
 // gr : https://grweb.ics.forth.gr/english/1617-B-2005.html
 // Submitted by registry <segred@ics.forth.gr> 2008-06-09
 gr
@@ -936,26 +1003,26 @@ edu.gr
 net.gr
 org.gr
 gov.gr
-
+ 
 // gs : http://en.wikipedia.org/wiki/.gs
 gs
-
+ 
 // gt : http://www.gt/politicas.html
 *.gt
-
+ 
 // gu : http://gadao.gov.gu/registration.txt
 *.gu
-
+ 
 // gw : http://en.wikipedia.org/wiki/.gw
 gw
-
+ 
 // gy : http://en.wikipedia.org/wiki/.gy
 // http://registry.gy/
 gy
 co.gy
 com.gy
 net.gy
-
+ 
 // hk : https://www.hkdnr.hk
 // Submitted by registry <hk.tech@hkirc.hk> 2008-06-11
 hk
@@ -980,10 +1047,10 @@ org.hk
 组织.hk
 組織.hk
 組织.hk 
-
+ 
 // hm : http://en.wikipedia.org/wiki/.hm
 hm
-
+ 
 // hn : http://www.nic.hn/politicas/ps02,,05.html
 hn
 com.hn
@@ -992,14 +1059,14 @@ org.hn
 net.hn
 mil.hn
 gob.hn
-
+ 
 // hr : http://www.dns.hr/documents/pdf/HRTLD-regulations.pdf
 hr
 iz.hr
 from.hr
 name.hr
 com.hr
-
+ 
 // ht : http://www.nic.ht/info/charte.cfm
 ht
 com.ht
@@ -1019,7 +1086,7 @@ edu.ht
 rel.ht
 gouv.ht
 perso.ht
-
+ 
 // hu : http://www.domain.hu/domain/English/sld.html
 // Confirmed by registry <pasztor@iszt.hu> 2008-06-12
 hu
@@ -1054,17 +1121,26 @@ szex.hu
 tozsde.hu
 utazas.hu
 video.hu
-
+ 
 // id : http://en.wikipedia.org/wiki/.id
-*.id
-
+// see also: https://register.pandi.or.id/
+id
+ac.id
+co.id
+go.id
+mil.id
+net.id
+or.id
+sch.id
+web.id
+ 
 // ie : http://en.wikipedia.org/wiki/.ie
 ie
 gov.ie
-
+ 
 // il : http://en.wikipedia.org/wiki/.il
 *.il
-
+ 
 // im : https://www.nic.im/pdfs/imfaqs.pdf
 im
 co.im
@@ -1075,7 +1151,7 @@ gov.im
 org.im
 nic.im
 ac.im
-
+ 
 // in : http://en.wikipedia.org/wiki/.in
 // see also: http://www.inregistry.in/policies/
 // Please note, that nic.in is not an offical eTLD, but used by most
@@ -1093,20 +1169,20 @@ edu.in
 res.in
 gov.in
 mil.in
-
+ 
 // info : http://en.wikipedia.org/wiki/.info
 info
-
+ 
 // int : http://en.wikipedia.org/wiki/.int
 // Confirmed by registry <iana-questions@icann.org> 2008-06-18
 int
 eu.int
-
+ 
 // io : http://www.nic.io/rules.html
 // list of other 2nd level tlds ?
 io
 com.io
-
+ 
 // iq : http://www.cmc.iq/english/iq/iqregister1.htm
 iq
 gov.iq
@@ -1115,8 +1191,10 @@ mil.iq
 com.iq
 org.iq
 net.iq
-
-// ir : http://www.nic.ir/ascii/Appendix1.htm
+ 
+// ir : http://www.nic.ir/Terms_and_Conditions_ir,_Appendix_1_Domain_Rules
+// Also see http://www.nic.ir/Internationalized_Domain_Names
+// Two <iran>.ir entries added at request of <tech-team@nic.ir>, 2010-04-16
 ir
 ac.ir
 co.ir
@@ -1125,7 +1203,11 @@ id.ir
 net.ir
 org.ir
 sch.ir
-
+// xn--mgba3a4f16a.ir (<iran>.ir, Persian YEH)
+ایران.ir
+// xn--mgba3a4fra.ir (<iran>.ir, Arabic YEH)
+ايران.ir
+ 
 // is : http://www.isnic.is/domain/rules.php
 // Confirmed by registry <marius@isgate.is> 2008-12-06
 is
@@ -1135,12 +1217,16 @@ edu.is
 gov.is
 org.is
 int.is
-
+ 
 // it : http://en.wikipedia.org/wiki/.it
 it
 gov.it
 edu.it
-// geo-names found at http://www.nic.it/RA/en/domini/regole/nomi-riservati.pdf
+// list of reserved geo-names : 
+// http://www.nic.it/documenti/regolamenti-e-linee-guida/regolamento-assegnazione-versione-6.0.pdf
+// (There is also a list of reserved geo-names corresponding to Italian 
+// municipalities : http://www.nic.it/documenti/appendice-c.pdf , but it is
+// not included here.)
 agrigento.it
 ag.it
 alessandria.it
@@ -1161,8 +1247,17 @@ avellino.it
 av.it
 bari.it
 ba.it
-barlettaandriatrani.it
-barletta-andria-trani.it
+andria-barletta-trani.it
+andriabarlettatrani.it
+trani-barletta-andria.it
+tranibarlettaandria.it
+barletta-trani-andria.it
+barlettatraniandria.it
+andria-trani-barletta.it
+andriatranibarletta.it
+trani-andria-barletta.it
+traniandriabarletta.it
+bt.it
 belluno.it
 bl.it
 benevento.it
@@ -1190,6 +1285,11 @@ caltanissetta.it
 cl.it
 campobasso.it
 cb.it
+carboniaiglesias.it
+carbonia-iglesias.it
+iglesias-carbonia.it
+iglesiascarbonia.it
+ci.it
 caserta.it
 ce.it
 catania.it
@@ -1208,11 +1308,16 @@ crotone.it
 kr.it
 cuneo.it
 cn.it
+dell-ogliastra.it
+dellogliastra.it
+ogliastra.it
+og.it
 enna.it
 en.it
-fermo.it
 ferrara.it
 fe.it
+fermo.it
+fm.it
 firenze.it
 florence.it
 fi.it
@@ -1220,6 +1325,8 @@ foggia.it
 fg.it
 forli-cesena.it
 forlicesena.it
+cesena-forli.it
+cesenaforli.it
 fc.it
 frosinone.it
 fr.it
@@ -1258,9 +1365,16 @@ mantova.it
 mn.it
 massa-carrara.it
 massacarrara.it
+carrara-massa.it
+carraramassa.it
 ms.it
 matera.it
 mt.it
+medio-campidano.it
+mediocampidano.it
+campidano-medio.it
+campidanomedio.it
+vs.it
 messina.it
 me.it
 milano.it
@@ -1269,6 +1383,12 @@ mi.it
 modena.it
 mo.it
 monza.it
+monza-brianza.it
+monzabrianza.it
+monzaebrianza.it
+monzaedellabrianza.it
+monza-e-della-brianza.it
+mb.it
 napoli.it
 naples.it
 na.it
@@ -1293,6 +1413,8 @@ pescara.it
 pe.it
 pesaro-urbino.it
 pesarourbino.it
+urbino-pesaro.it
+urbinopesaro.it
 pu.it
 piacenza.it
 pc.it
@@ -1339,6 +1461,11 @@ sondrio.it
 so.it
 taranto.it
 ta.it
+tempio-olbia.it
+tempioolbia.it
+olbia-tempio.it
+olbiatempio.it
+ot.it
 teramo.it
 te.it
 terni.it
@@ -1375,7 +1502,7 @@ vicenza.it
 vi.it
 viterbo.it
 vt.it
-
+ 
 // je : http://www.channelisles.net/applic/avextn.shtml
 je
 co.je
@@ -1383,10 +1510,10 @@ org.je
 net.je
 sch.je
 gov.je
-
+ 
 // jm : http://www.com.jm/register.html
 *.jm
-
+ 
 // jo : http://www.dns.jo/Registration_policy.aspx
 jo
 com.jo
@@ -1397,10 +1524,10 @@ sch.jo
 gov.jo
 mil.jo
 name.jo
-
+ 
 // jobs : http://en.wikipedia.org/wiki/.jobs
 jobs
-
+ 
 // jp : http://en.wikipedia.org/wiki/.jp
 // http://jprs.co.jp/en/jpdomain.html
 // Submitted by registry <yone@jprs.co.jp> 2008-06-11
@@ -1535,10 +1662,10 @@ or.jp
 !city.sendai.jp
 !city.shizuoka.jp
 !city.yokohama.jp
-
+ 
 // ke : http://www.kenic.or.ke/index.php?option=com_content&task=view&id=117&Itemid=145
 *.ke
-
+ 
 // kg : http://www.domain.kg/dmn_n.html
 kg
 org.kg
@@ -1547,10 +1674,10 @@ com.kg
 edu.kg
 gov.kg
 mil.kg
-
+ 
 // kh : http://www.mptc.gov.kh/dns_registration.htm
 *.kh
-
+ 
 // ki : http://www.ki/dns/index.html
 ki
 edu.ki
@@ -1560,7 +1687,7 @@ org.ki
 gov.ki
 info.ki
 com.ki
-
+ 
 // km : http://en.wikipedia.org/wiki/.km
 // http://www.domaine.km/documents/charte.doc
 km
@@ -1583,7 +1710,7 @@ notaires.km
 pharmaciens.km
 veterinaire.km
 gouv.km
-
+ 
 // kn : http://en.wikipedia.org/wiki/.kn
 // http://www.dot.kn/domainRules.html
 kn
@@ -1591,7 +1718,15 @@ net.kn
 org.kn
 edu.kn
 gov.kn
-
+ 
+// kp : http://www.kcce.kp/en_index.php
+com.kp
+edu.kp
+gov.kp
+org.kp
+rep.kp
+tra.kp
+ 
 // kr : http://en.wikipedia.org/wiki/.kr
 // see also: http://domain.nida.or.kr/eng/registration.jsp
 kr
@@ -1625,10 +1760,10 @@ jeonbuk.kr
 jeonnam.kr
 seoul.kr
 ulsan.kr
-
+ 
 // kw : http://en.wikipedia.org/wiki/.kw
 *.kw
-
+ 
 // ky : http://www.icta.ky/da_ky_reg_dom.php
 // Confirmed by registry <kysupport@perimeterusa.com> 2008-06-17
 ky
@@ -1637,7 +1772,7 @@ gov.ky
 com.ky
 org.ky
 net.ky
-
+ 
 // kz : http://en.wikipedia.org/wiki/.kz
 // see also: http://www.nic.kz/rules/index.jsp
 kz
@@ -1647,7 +1782,7 @@ net.kz
 gov.kz
 mil.kz
 com.kz
-
+ 
 // la : http://en.wikipedia.org/wiki/.la
 // Submitted by registry <gavin.brown@nic.la> 2008-06-10
 la
@@ -1661,7 +1796,7 @@ com.la
 org.la
 // see http://www.c.la/
 c.la
-
+ 
 // lb : http://en.wikipedia.org/wiki/.lb
 // Submitted by registry <randy@psg.com> 2008-06-17
 com.lb
@@ -1669,7 +1804,7 @@ edu.lb
 gov.lb
 net.lb
 org.lb
-
+ 
 // lc : http://en.wikipedia.org/wiki/.lc
 // see also: http://www.nic.lc/rules.htm
 lc
@@ -1679,10 +1814,10 @@ co.lc
 org.lc
 edu.lc
 gov.lc
-
+ 
 // li : http://en.wikipedia.org/wiki/.li
 li
-
+ 
 // lk : http://www.nic.lk/seclevpr.html
 lk
 gov.lk
@@ -1699,10 +1834,10 @@ ltd.lk
 assn.lk
 grp.lk
 hotel.lk
-
+ 
 // local : http://en.wikipedia.org/wiki/.local
 local
-
+ 
 // lr : http://psg.com/dns/lr/lr.txt
 // Submitted by registry <randy@psg.com> 2008-06-17
 com.lr
@@ -1710,20 +1845,20 @@ edu.lr
 gov.lr
 org.lr
 net.lr
-
+ 
 // ls : http://en.wikipedia.org/wiki/.ls
 ls
 co.ls
 org.ls
-
+ 
 // lt : http://en.wikipedia.org/wiki/.lt
 lt
 // gov.lt : http://www.gov.lt/index_en.php
 gov.lt
-
+ 
 // lu : http://www.dns.lu/en/
 lu
-
+ 
 // lv : http://www.nic.lv/DNS/En/generic.php
 lv
 com.lv
@@ -1735,7 +1870,7 @@ id.lv
 net.lv
 asn.lv
 conf.lv
-
+ 
 // ly : http://www.nic.ly/regulations.php
 ly
 com.ly
@@ -1747,7 +1882,7 @@ sch.ly
 med.ly
 org.ly
 id.ly
-
+ 
 // ma : http://en.wikipedia.org/wiki/.ma
 // http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
 ma
@@ -1757,15 +1892,15 @@ gov.ma
 org.ma
 ac.ma
 press.ma
-
+ 
 // mc : http://www.nic.mc/
 mc
 tm.mc
 asso.mc
-
+ 
 // md : http://en.wikipedia.org/wiki/.md
 md
-
+ 
 // me : http://en.wikipedia.org/wiki/.me
 me
 co.me
@@ -1776,7 +1911,7 @@ ac.me
 gov.me
 its.me
 priv.me
-
+ 
 // mg : http://www.nic.mg/tarif.htm
 mg
 org.mg
@@ -1787,13 +1922,13 @@ tm.mg
 edu.mg
 mil.mg
 com.mg
-
+ 
 // mh : http://en.wikipedia.org/wiki/.mh
 mh
-
+ 
 // mil : http://en.wikipedia.org/wiki/.mil
 mil
-
+ 
 // mk : http://en.wikipedia.org/wiki/.mk
 // see also: http://dns.marnet.net.mk/postapka.php
 mk
@@ -1804,19 +1939,27 @@ edu.mk
 gov.mk
 inf.mk
 name.mk
-
+ 
 // ml : http://www.gobin.info/domainname/ml-template.doc
-*.ml
-
+// see also: http://en.wikipedia.org/wiki/.ml
+ml
+com.ml
+edu.ml
+gouv.ml
+gov.ml
+net.ml
+org.ml
+presse.ml
+ 
 // mm : http://en.wikipedia.org/wiki/.mm
 *.mm
-
+ 
 // mn : http://en.wikipedia.org/wiki/.mn
 mn
 gov.mn
 edu.mn
 org.mn
-
+ 
 // mo : http://www.monic.net.mo/
 mo
 com.mo
@@ -1824,27 +1967,27 @@ net.mo
 org.mo
 edu.mo
 gov.mo
-
+ 
 // mobi : http://en.wikipedia.org/wiki/.mobi
 mobi
-
+ 
 // mp : http://www.dot.mp/
 // Confirmed by registry <dcamacho@saipan.com> 2008-06-17
 mp
-
+ 
 // mq : http://en.wikipedia.org/wiki/.mq
 mq
-
+ 
 // mr : http://en.wikipedia.org/wiki/.mr
 mr
 gov.mr
-
+ 
 // ms : http://en.wikipedia.org/wiki/.ms
 ms
-
+ 
 // mt : https://www.nic.org.mt/dotmt/
 *.mt
-
+ 
 // mu : http://en.wikipedia.org/wiki/.mu
 mu
 com.mu
@@ -1854,7 +1997,7 @@ gov.mu
 ac.mu
 co.mu
 or.mu
-
+ 
 // museum : http://about.museum/naming/
 // http://index.museum/
 museum
@@ -2406,10 +2549,25 @@ zoological.museum
 zoology.museum
 ירושלים.museum
 иком.museum
-
+ 
 // mv : http://en.wikipedia.org/wiki/.mv
-*.mv
-
+// "mv" included because, contra Wikipedia, google.mv exists.
+mv
+aero.mv
+biz.mv
+com.mv
+coop.mv
+edu.mv
+gov.mv
+info.mv
+int.mv
+mil.mv
+museum.mv
+name.mv
+net.mv
+org.mv
+pro.mv
+ 
 // mw : http://www.registrar.mw/
 mw
 ac.mw
@@ -2420,9 +2578,10 @@ coop.mw
 edu.mw
 gov.mw
 int.mw
+museum.mw
 net.mw
 org.mw
-
+ 
 // mx : http://www.nic.mx/
 // Submitted by registry <farias@nic.mx> 2008-06-19
 mx
@@ -2431,7 +2590,7 @@ org.mx
 gob.mx
 edu.mx
 net.mx
-
+ 
 // my : http://www.mynic.net.my/
 my
 com.my
@@ -2441,10 +2600,10 @@ gov.my
 edu.my
 mil.my
 name.my
-
+ 
 // mz : http://www.gobin.info/domainname/mz-template.doc
 *.mz
-
+ 
 // na : http://www.na-nic.com.na/
 // http://www.info.na/domain/
 na
@@ -2465,29 +2624,30 @@ mobi.na
 co.na
 com.na
 org.na
-
+ 
 // name : has 2nd-level tlds, but there's no list of them
 name
-
+ 
 // nc : http://www.cctld.nc/
 nc
-
+asso.nc
+ 
 // ne : http://en.wikipedia.org/wiki/.ne
 ne
-
+ 
 // net : http://en.wikipedia.org/wiki/.net
 net
-
+ 
 // CentralNic names : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com> 2008-06-17
 gb.net
 se.net
 uk.net
-
+ 
 // ZaNiC names : http://www.za.net/
 // Confirmed by registry <hostmaster@nic.za.net> 2009-10-03
 za.net
-
+ 
 // nf : http://en.wikipedia.org/wiki/.nf
 nf
 com.nf
@@ -2500,7 +2660,7 @@ firm.nf
 info.nf
 other.nf
 store.nf
-
+ 
 // ng : http://psg.com/dns/ng/
 // Submitted by registry <randy@psg.com> 2008-06-17
 ac.ng
@@ -2509,15 +2669,21 @@ edu.ng
 gov.ng
 net.ng
 org.ng
-
+ 
 // ni : http://www.nic.ni/dominios.htm
 *.ni
-
+ 
 // nl : http://www.domain-registry.nl/ace.php/c,728,122,,,,Home.html
 // Confirmed by registry <Antoin.Verschuren@sidn.nl> (with technical
 // reservations) 2008-06-08
 nl
-
+ 
+// BV.nl will be a registry for dutch BV's (besloten vennootschap)
+bv.nl
+ 
+// the co.nl domain is managed by CoDNS B.V. Added 2010-05-23.
+co.nl
+ 
 // no : http://www.norid.no/regelverk/index.en.html
 // The Norwegian registry has declined to notify us of updates. The web pages
 // referenced below are the official source of the data. There is also an
@@ -3284,10 +3450,13 @@ valer.ostfold.no
 våler.østfold.no
 valer.hedmark.no
 våler.hedmark.no
-
+ 
+// the co.no domain is managed by CoDNS B.V. Added 2010-05-23.
+co.no
+ 
 // np : http://www.mos.com.np/register.html
 *.np
-
+ 
 // nr : http://cenpac.net.nr/dns/index.html
 // Confirmed by registry <technician@cenpac.net.nr> 2008-06-17
 nr
@@ -3298,27 +3467,37 @@ edu.nr
 org.nr
 net.nr
 com.nr
-
+ 
 // nu : http://en.wikipedia.org/wiki/.nu
 nu
-
+ 
 // nz : http://en.wikipedia.org/wiki/.nz
 *.nz
-
+ 
 // om : http://en.wikipedia.org/wiki/.om
 *.om
-
+!mediaphone.om
+!nawrastelecom.om
+!nawras.om
+!omanmobile.om
+!omanpost.om
+!omantel.om
+!rakpetroleum.om
+!siemens.om
+!songfest.om
+!statecouncil.om
+ 
 // org : http://en.wikipedia.org/wiki/.org
 org
-
+ 
 // CentralNic names : http://www.centralnic.com/names/domains
 // Submitted by registry <gavin.brown@centralnic.com> 2008-06-17
 ae.org
-
+ 
 // ZaNiC names : http://www.za.net/
 // Confirmed by registry <hostmaster@nic.za.net> 2009-10-03
 za.org
-
+ 
 // pa : http://www.nic.pa/
 // Some additional second level "domains" resolve directly as hostnames, such as
 // pannet.pa, so we add a rule for "pa".
@@ -3334,7 +3513,7 @@ ing.pa
 abo.pa
 med.pa
 nom.pa
-
+ 
 // pe : https://www.nic.pe/InformeFinalComision.pdf
 pe
 edu.pe
@@ -3344,16 +3523,16 @@ mil.pe
 org.pe
 com.pe
 net.pe
-
+ 
 // pf : http://www.gobin.info/domainname/formulaire-pf.pdf
 pf
 com.pf
 org.pf
 edu.pf
-
+ 
 // pg : http://en.wikipedia.org/wiki/.pg
 *.pg
-
+ 
 // ph : http://www.domains.ph/FAQ2.asp
 // Submitted by registry <jed@email.com.ph> 2008-06-13
 ph
@@ -3365,7 +3544,7 @@ edu.ph
 ngo.ph
 mil.ph
 i.ph
-
+ 
 // pk : http://pk5.pknic.net.pk/pk5/msgNamepk.PK
 pk
 com.pk
@@ -3382,7 +3561,7 @@ gon.pk
 gop.pk
 gos.pk
 info.pk
-
+ 
 // pl : http://www.dns.pl/english/
 pl
 // NASK functional domains (nask.pl / dns.pl) : http://www.dns.pl/english/dns-funk.html
@@ -3435,7 +3614,6 @@ sr.gov.pl
 po.gov.pl
 pa.gov.pl
 // other functional domains
-med.pl
 ngo.pl
 irc.pl
 usenet.pl
@@ -3525,6 +3703,7 @@ rybnik.pl
 rzeszow.pl
 sanok.pl
 sejny.pl
+siedlce.pl
 slask.pl
 slupsk.pl
 sosnowiec.pl
@@ -3563,6 +3742,7 @@ zgorzelec.pl
 gda.pl
 gdansk.pl
 gdynia.pl
+med.pl
 sopot.pl
 // other geographical domains
 gliwice.pl
@@ -3570,7 +3750,10 @@ krakow.pl
 poznan.pl
 wroc.pl
 zakopane.pl
-
+ 
+// co.pl : Mainseek Sp. z o.o. http://www.co.pl
+co.pl
+ 
 // pn : http://www.government.pn/PnRegistry/policies.htm
 pn
 gov.pn
@@ -3578,7 +3761,7 @@ co.pn
 org.pn
 edu.pn
 net.pn
-
+ 
 // pr : http://www.nic.pr/index.asp?f=1
 pr
 com.pr
@@ -3595,7 +3778,7 @@ name.pr
 est.pr
 prof.pr
 ac.pr
-
+ 
 // pro : http://www.nic.pro/support_faq.htm
 pro
 aca.pro
@@ -3605,7 +3788,7 @@ jur.pro
 law.pro
 med.pro
 eng.pro
-
+ 
 // ps : http://en.wikipedia.org/wiki/.ps
 // http://www.nic.ps/registration/policy.html#reg
 ps
@@ -3616,7 +3799,7 @@ plo.ps
 com.ps
 org.ps
 net.ps
-
+ 
 // pt : http://online.dns.pt/dns/start_dns
 pt
 net.pt
@@ -3627,7 +3810,7 @@ int.pt
 publ.pt
 com.pt
 nome.pt
-
+ 
 // pw : http://en.wikipedia.org/wiki/.pw
 pw
 co.pw
@@ -3636,19 +3819,19 @@ or.pw
 ed.pw
 go.pw
 belau.pw
-
+ 
 // py : http://www.nic.py/faq_a.html#faq_b
 *.py
-
+ 
 // qa : http://www.qatar.net.qa/services/virtual.htm
 *.qa
-
+ 
 // re : http://www.afnic.re/obtenir/chartes/nommage-re/annexe-descriptifs
 re
 com.re
 asso.re
 nom.re
-
+ 
 // ro : http://www.rotld.ro/
 ro
 com.ro
@@ -3662,7 +3845,7 @@ arts.ro
 firm.ro
 store.ro
 www.ro
-
+ 
 // rs : http://en.wikipedia.org/wiki/.rs
 rs
 co.rs
@@ -3671,7 +3854,7 @@ edu.rs
 ac.rs
 gov.rs
 in.rs
-
+ 
 // ru : http://www.cctld.ru/ru/docs/aktiv_8.php
 // Industry domains
 ru
@@ -3812,7 +3995,7 @@ gov.ru
 mil.ru
 // Technical domains
 test.ru
-
+ 
 // rw : http://www.nic.rw/cgi-bin/policy.pl
 rw
 gov.rw
@@ -3824,8 +4007,9 @@ co.rw
 int.rw
 mil.rw
 gouv.rw
-
+ 
 // sa : http://www.nic.net.sa/
+sa
 com.sa
 net.sa
 org.sa
@@ -3834,7 +4018,7 @@ med.sa
 pub.sa
 edu.sa
 sch.sa
-
+ 
 // sb : http://www.sbnic.net.sb/
 // Submitted by registry <lee.humphries@telekom.com.sb> 2008-06-08
 sb
@@ -3843,7 +4027,7 @@ edu.sb
 gov.sb
 net.sb
 org.sb
-
+ 
 // sc : http://www.nic.sc/
 sc
 com.sc
@@ -3851,7 +4035,7 @@ gov.sc
 net.sc
 org.sc
 edu.sc
-
+ 
 // sd : http://www.isoc.sd/sudanic.isoc.sd/billing_pricing.htm
 // Submitted by registry <admin@isoc.sd> 2008-06-17
 sd
@@ -3862,7 +4046,7 @@ edu.sd
 med.sd
 gov.sd
 info.sd
-
+ 
 // se : http://en.wikipedia.org/wiki/.se
 // Submitted by registry <Patrik.Wallstrom@iis.se> 2008-06-24
 se
@@ -3906,7 +4090,7 @@ w.se
 x.se
 y.se
 z.se
-
+ 
 // sg : http://www.nic.net.sg/sub_policies_agreement/2ld.html
 sg
 com.sg
@@ -3915,21 +4099,21 @@ org.sg
 gov.sg
 edu.sg
 per.sg
-
+ 
 // sh : http://www.nic.sh/rules.html
 // list of 2nd level domains ?
 sh
-
+ 
 // si : http://en.wikipedia.org/wiki/.si
 si
-
+ 
 // sj : No registrations at this time.
 // Submitted by registry <jarle@uninett.no> 2008-06-16
-
+ 
 // sk : http://en.wikipedia.org/wiki/.sk
 // list of 2nd level domains ?
 sk
-
+ 
 // sl : http://www.nic.sl
 // Submitted by registry <adam@neoip.com> 2008-06-12
 sl
@@ -3938,36 +4122,50 @@ net.sl
 edu.sl
 gov.sl
 org.sl
-
+ 
 // sm : http://en.wikipedia.org/wiki/.sm
 sm
-
+ 
 // sn : http://en.wikipedia.org/wiki/.sn
 sn
-
+art.sn
+com.sn
+edu.sn
+gouv.sn
+org.sn
+perso.sn
+univ.sn
+ 
+// so : http://www.soregistry.com/
+so
+com.so
+net.so
+org.so
+ 
 // sr : http://en.wikipedia.org/wiki/.sr
 sr
-
+ 
 // st : http://www.nic.st/html/policyrules/
 st
-gov.st
-saotome.st
-principe.st
-consulado.st
-org.st
-edu.st
-net.st
-com.st
-store.st
-mil.st
 co.st
-
+com.st
+consulado.st
+edu.st
+embaixada.st
+gov.st
+mil.st
+net.st
+org.st
+principe.st
+saotome.st
+store.st
+ 
 // su : http://en.wikipedia.org/wiki/.su
 su
-
+ 
 // sv : http://www.svnet.org.sv/svpolicy.html
 *.sv
-
+ 
 // sy : http://en.wikipedia.org/wiki/.sy
 // see also: http://www.gobin.info/domainname/sy.doc
 sy
@@ -3977,32 +4175,32 @@ net.sy
 mil.sy
 com.sy
 org.sy
-
+ 
 // sz : http://en.wikipedia.org/wiki/.sz
 // http://www.sispa.org.sz/
 sz
 co.sz
 ac.sz
 org.sz
-
+ 
 // tc : http://en.wikipedia.org/wiki/.tc
 tc
-
+ 
 // td : http://en.wikipedia.org/wiki/.td
 td
-
+ 
 // tel: http://en.wikipedia.org/wiki/.tel
 // http://www.telnic.org/
 tel
-
+ 
 // tf : http://en.wikipedia.org/wiki/.tf
 tf
-
+ 
 // tg : http://en.wikipedia.org/wiki/.tg
 // http://www.nic.tg/nictg/index.php implies no reserved 2nd-level domains,
 // although this contradicts wikipedia.
 tg
-
+ 
 // th : http://en.wikipedia.org/wiki/.th
 // Submitted by registry <krit@thains.co.th> 2008-06-17
 th
@@ -4013,34 +4211,36 @@ in.th
 mi.th
 net.th
 or.th
-
+ 
 // tj : http://www.nic.tj/policy.htm
 tj
 ac.tj
 biz.tj
-com.tj
 co.tj
+com.tj
 edu.tj
+go.tj
+gov.tj
 int.tj
+mil.tj
 name.tj
 net.tj
+nic.tj
 org.tj
+test.tj
 web.tj
-gov.tj
-go.tj
-mil.tj
-
+ 
 // tk : http://en.wikipedia.org/wiki/.tk
 tk
-
+ 
 // tl : http://en.wikipedia.org/wiki/.tl
 tl
 gov.tl
-
+ 
 // tm : http://www.nic.tm/rules.html
 // list of 2nd level tlds ?
 tm
-
+ 
 // tn : http://en.wikipedia.org/wiki/.tn
 // http://whois.ati.tn/
 tn
@@ -4064,7 +4264,7 @@ mincom.tn
 agrinet.tn
 defense.tn
 turen.tn
-
+ 
 // to : http://en.wikipedia.org/wiki/.to
 // Submitted by registry <egullich@colo.to> 2008-06-17
 to
@@ -4074,13 +4274,17 @@ net.to
 org.to
 edu.to
 mil.to
-
+ 
 // tr : http://en.wikipedia.org/wiki/.tr
 *.tr
-
+!nic.tr
+// Used by government in the TRNC
+// http://en.wikipedia.org/wiki/.nc.tr
+gov.nc.tr
+ 
 // travel : http://en.wikipedia.org/wiki/.travel
 travel
-
+ 
 // tt : http://www.nic.tt/
 tt
 co.tt
@@ -4100,15 +4304,12 @@ aero.tt
 name.tt
 gov.tt
 edu.tt
-
+ 
 // tv : http://en.wikipedia.org/wiki/.tv
-// list of other 2nd level tlds ?
+// Not listing any 2LDs as reserved since none seem to exist in practice,
+// Wikipedia notwithstanding.
 tv
-com.tv
-net.tv
-org.tv
-gov.tv
-
+ 
 // tw : http://en.wikipedia.org/wiki/.tw
 tw
 edu.tw
@@ -4124,15 +4325,18 @@ club.tw
 網路.tw
 組織.tw
 商業.tw
-
+ 
 // tz : http://en.wikipedia.org/wiki/.tz
 // Submitted by registry <randy@psg.com> 2008-06-17
+// Updated from http://www.tznic.or.tz/index.php/domains.html 2010-10-25
 ac.tz
 co.tz
 go.tz
+mil.tz
 ne.tz
 or.tz
-
+sc.tz
+ 
 // ua : http://www.nic.net.ua/
 ua
 com.ua
@@ -4188,7 +4392,7 @@ zaporizhzhe.ua
 zp.ua
 zhitomir.ua
 zt.ua
-
+ 
 // ug : http://www.registry.co.ug/
 ug
 co.ug
@@ -4197,20 +4401,24 @@ sc.ug
 go.ug
 ne.ug
 or.ug
-
+ 
 // uk : http://en.wikipedia.org/wiki/.uk
 *.uk
 *.sch.uk
 !bl.uk
 !british-library.uk
 !icnet.uk
+!gov.uk
 !jet.uk
+!mod.uk
 !nel.uk
 !nhs.uk
+!nic.uk
 !nls.uk
 !national-library-scotland.uk
 !parliament.uk
-
+!police.uk
+ 
 // us : http://en.wikipedia.org/wiki/.us
 us
 dni.us
@@ -4277,20 +4485,197 @@ wy.us
 // The registrar notes several more specific domains available in each state,
 // such as state.*.us, dst.*.us, etc., but resolution of these is somewhat
 // haphazard; in some states these domains resolve as addresses, while in others
-// only subdomains are avilable, or even nothing at all.
-
+// only subdomains are available, or even nothing at all. We include the
+// most common ones where it's clear that different sites are different
+// entities.
+k12.ak.us
+k12.al.us
+k12.ar.us
+k12.as.us
+k12.az.us
+k12.ca.us
+k12.co.us
+k12.ct.us
+k12.dc.us
+k12.de.us
+k12.fl.us
+k12.ga.us
+k12.gu.us
+// k12.hi.us  Hawaii has a state-wide DOE login: bug 614565
+k12.ia.us
+k12.id.us
+k12.il.us
+k12.in.us
+k12.ks.us
+k12.ky.us
+k12.la.us
+k12.ma.us
+k12.md.us
+k12.me.us
+k12.mi.us
+k12.mn.us
+k12.mo.us
+k12.ms.us
+k12.mt.us
+k12.nc.us
+k12.nd.us
+k12.ne.us
+k12.nh.us
+k12.nj.us
+k12.nm.us
+k12.nv.us
+k12.ny.us
+k12.oh.us
+k12.ok.us
+k12.or.us
+k12.pa.us
+k12.pr.us
+k12.ri.us
+k12.sc.us
+k12.sd.us
+k12.tn.us
+k12.tx.us
+k12.ut.us
+k12.vi.us
+k12.vt.us
+k12.va.us
+k12.wa.us
+k12.wi.us
+k12.wv.us
+k12.wy.us
+ 
+cc.ak.us
+cc.al.us
+cc.ar.us
+cc.as.us
+cc.az.us
+cc.ca.us
+cc.co.us
+cc.ct.us
+cc.dc.us
+cc.de.us
+cc.fl.us
+cc.ga.us
+cc.gu.us
+cc.hi.us
+cc.ia.us
+cc.id.us
+cc.il.us
+cc.in.us
+cc.ks.us
+cc.ky.us
+cc.la.us
+cc.ma.us
+cc.md.us
+cc.me.us
+cc.mi.us
+cc.mn.us
+cc.mo.us
+cc.ms.us
+cc.mt.us
+cc.nc.us
+cc.nd.us
+cc.ne.us
+cc.nh.us
+cc.nj.us
+cc.nm.us
+cc.nv.us
+cc.ny.us
+cc.oh.us
+cc.ok.us
+cc.or.us
+cc.pa.us
+cc.pr.us
+cc.ri.us
+cc.sc.us
+cc.sd.us
+cc.tn.us
+cc.tx.us
+cc.ut.us
+cc.vi.us
+cc.vt.us
+cc.va.us
+cc.wa.us
+cc.wi.us
+cc.wv.us
+cc.wy.us
+ 
+lib.ak.us
+lib.al.us
+lib.ar.us
+lib.as.us
+lib.az.us
+lib.ca.us
+lib.co.us
+lib.ct.us
+lib.dc.us
+lib.de.us
+lib.fl.us
+lib.ga.us
+lib.gu.us
+lib.hi.us
+lib.ia.us
+lib.id.us
+lib.il.us
+lib.in.us
+lib.ks.us
+lib.ky.us
+lib.la.us
+lib.ma.us
+lib.md.us
+lib.me.us
+lib.mi.us
+lib.mn.us
+lib.mo.us
+lib.ms.us
+lib.mt.us
+lib.nc.us
+lib.nd.us
+lib.ne.us
+lib.nh.us
+lib.nj.us
+lib.nm.us
+lib.nv.us
+lib.ny.us
+lib.oh.us
+lib.ok.us
+lib.or.us
+lib.pa.us
+lib.pr.us
+lib.ri.us
+lib.sc.us
+lib.sd.us
+lib.tn.us
+lib.tx.us
+lib.ut.us
+lib.vi.us
+lib.vt.us
+lib.va.us
+lib.wa.us
+lib.wi.us
+lib.wv.us
+lib.wy.us
+ 
+// k12.ma.us contains school districts in Massachusetts. The 4LDs are 
+//  managed indepedently except for private (PVT), charter (CHTR) and
+//  parochial (PAROCH) schools.  Those are delegated dorectly to the 
+//  5LD operators.   <k12-ma-hostmaster _ at _ rsuc.gweep.net>
+pvt.k12.ma.us
+chtr.k12.ma.us
+paroch.k12.ma.us
+ 
 // uy : http://www.antel.com.uy/
 *.uy
-
+ 
 // uz : http://www.reg.uz/registerr.html
 // are there other 2nd level tlds ?
 uz
 com.uz
 co.uz
-
+ 
 // va : http://en.wikipedia.org/wiki/.va
 va
-
+ 
 // vc : http://en.wikipedia.org/wiki/.vc
 // Submitted by registry <kshah@ca.afilias.info> 2008-06-13
 vc
@@ -4300,13 +4685,13 @@ org.vc
 gov.vc
 mil.vc
 edu.vc
-
+ 
 // ve : http://registro.nic.ve/nicve/registro/index.html
 *.ve
-
+ 
 // vg : http://en.wikipedia.org/wiki/.vg
 vg
-
+ 
 // vi : http://www.nic.vi/newdomainform.htm
 // http://www.nic.vi/Domain_Rules/body_domain_rules.html indicates some other
 // TLDs are "reserved", such as edu.vi and gov.vi, but doesn't actually say they
@@ -4317,7 +4702,7 @@ com.vi
 k12.vi
 net.vi
 org.vi
-
+ 
 // vn : https://www.dot.vn/vnnic/vnnic/domainregistration.jsp
 vn
 com.vn
@@ -4332,11 +4717,11 @@ info.vn
 name.vn
 pro.vn
 health.vn
-
+ 
 // vu : http://en.wikipedia.org/wiki/.vu
 // list of 2nd level tlds ?
 vu
-
+ 
 // ws : http://en.wikipedia.org/wiki/.ws
 // http://samoanic.ws/index.dhtml
 ws
@@ -4345,18 +4730,462 @@ net.ws
 org.ws
 gov.ws
 edu.ws
-
+ 
+// IDN ccTLDs
+// Please sort by ISO 3166 ccTLD, then punicode string
+// when submitting patches and follow this format:
+// <Punicode> ("<english word>" <language>) : <ISO 3166 ccTLD>
+// [optional sponsoring org]
+// <URL>
+ 
+// xn--mgbaam7a8h ("Emerat" Arabic) : AE
+//http://nic.ae/english/arabicdomain/rules.jsp
+امارات
+ 
+// xn--54b7fta0cc ("Bangla" Bangla) : BD  
+বাংলা
+ 
+// xn--fiqs8s ("China" Chinese-Han-Simplified <.Zhonggou>) : CN 
+// CNNIC
+// http://cnnic.cn/html/Dir/2005/10/11/3218.htm
+中国
+ 
+// xn--fiqz9s ("China" Chinese-Han-Traditional <.Zhonggou>) : CN
+// CNNIC
+// http://cnnic.cn/html/Dir/2005/10/11/3218.htm
+中國
+ 
+// xn--lgbbat1ad8j ("Algeria / Al Jazair" Arabic) : DZ  
+الجزائر
+ 
+// xn--wgbh1c ("Egypt" Arabic .masr) : EG
+// http://www.dotmasr.eg/
+مصر
+ 
+// xn--node ("ge" Georgian (Mkhedruli)) : GE  
+გე
+ 
+// xn--j6w193g ("Hong Kong" Chinese-Han) : HK
+// https://www2.hkirc.hk/register/rules.jsp
+香港
+ 
+// xn--h2brj9c ("Bharat" Devanagari) : IN  
+// India
+भारत
+ 
+// xn--mgbbh1a71e ("Bharat" Arabic) : IN  
+// India
+بھارت
+ 
+// xn--fpcrj9c3d ("Bharat" Telugu) : IN  
+// India
+భారత్
+ 
+// xn--gecrj9c ("Bharat" Gujarati) : IN  
+// India
+ભારત
+ 
+// xn--s9brj9c ("Bharat" Gurmukhi) : IN  
+// India
+ਭਾਰਤ
+ 
+// xn--45brj9c ("Bharat" Bengali) : IN  
+// India
+ভারত
+ 
+// xn--xkc2dl3a5ee0h ("India" Tamil) : IN  
+// India
+இந்தியா
+ 
+// xn--mgba3a4f16a ("Iran" Persian) : IR  
+ایران
+ 
+// xn--mgba3a4fra ("Iran" Arabic) : IR  
+ايران
+ 
+//xn--mgbayh7gpa ("al-Ordon" Arabic) JO
+//National Information Technology Center (NITC) 
+//Royal Scientific Society, Al-Jubeiha
+الاردن
+ 
+// xn--3e0b707e ("Republic of Korea" Hangul) : KR  
+한국
+ 
+// xn--fzc2c9e2c ("Lanka" Sinhalese-Sinhala) : LK
+// http://nic.lk
+ලංකා
+ 
+// xn--xkc2al3hye2a ("Ilangai" Tamil) : LK
+// http://nic.lk
+இலங்கை
+ 
+// xn--mgbc0a9azcg ("Morocco / al-Maghrib" Arabic) : MA  
+المغرب
+ 
+// xn--mgb9awbf ("Oman" Arabic) : OM  
+عمان
+ 
+// xn--ygbi2ammx ("Falasteen" Arabic) : PS
+// The Palestinian National Internet Naming Authority (PNINA)
+// http://www.pnina.ps
+فلسطين
+ 
+// xn--90a3ac ("srb" Cyrillic) : RS  
+срб
+ 
+// xn--p1ai ("rf" Russian-Cyrillic) : RU
+// http://www.cctld.ru/en/docs/rulesrf.php
+рф
+ 
+// xn--wgbl6a ("Qatar" Arabic) : QA
+// http://www.ict.gov.qa/
+قطر
+ 
+// xn--mgberp4a5d4ar ("AlSaudiah" Arabic) : SA
+// http://www.nic.net.sa/
+السعودية
+ 
+// xn--mgberp4a5d4a87g ("AlSaudiah" Arabic) variant : SA  
+السعودیة
+ 
+// xn--mgbqly7c0a67fbc ("AlSaudiah" Arabic) variant : SA  
+السعودیۃ
+ 
+// xn--mgbqly7cvafr ("AlSaudiah" Arabic) variant : SA  
+السعوديه
+ 
+// xn--ogbpf8fl ("Syria" Arabic) : SY  
+سورية
+ 
+// xn--mgbtf8fl ("Syria" Arabic) variant : SY  
+سوريا
+ 
+// xn--yfro4i67o Singapore ("Singapore" Chinese-Han) : SG
+新加坡
+ 
+// xn--clchc0ea0b2g2a9gcd ("Singapore" Tamil) : SG
+சிங்கப்பூர்
+ 
+// xn--o3cw4h ("Thai" Thai) : TH
+// http://www.thnic.co.th
+ไทย
+ 
+// xn--pgbs0dh ("Tunis") : TN
+// http://nic.tn
+تونس
+ 
+// xn--kpry57d ("Taiwan" Chinese-Han-Traditional) : TW
+// http://www.twnic.net/english/dn/dn_07a.htm
+台灣
+ 
+// xn--kprw13d ("Taiwan" Chinese-Han-Simplified) : TW
+// http://www.twnic.net/english/dn/dn_07a.htm
+台湾
+ 
+// xn--nnx388a ("Taiwan") variant : TW  
+臺灣
+ 
+// xn--j1amh ("ukr" Cyrillic) : UA  
+укр
+ 
+// xn--mgb2ddes ("AlYemen" Arabic) : YE  
+اليمن
+ 
+// xxx : http://icmregistry.com
+xxx
+ 
 // ye : http://www.y.net.ye/services/domain_name.htm
 *.ye
-
+ 
 // yu : http://www.nic.yu/pravilnik-e.html
 *.yu
-
+ 
 // za : http://www.zadna.org.za/slds.html
 *.za
-
+ 
 // zm : http://en.wikipedia.org/wiki/.zm
 *.zm
-
+ 
 // zw : http://en.wikipedia.org/wiki/.zw
 *.zw
+ 
+// DynDNS.com Dynamic DNS zones : http://www.dyndns.com/services/dns/dyndns/
+dyndns-at-home.com
+dyndns-at-work.com
+dyndns-blog.com
+dyndns-free.com
+dyndns-home.com
+dyndns-ip.com
+dyndns-mail.com
+dyndns-office.com
+dyndns-pics.com
+dyndns-remote.com
+dyndns-server.com
+dyndns-web.com
+dyndns-wiki.com
+dyndns-work.com
+dyndns.biz
+dyndns.info
+dyndns.org
+dyndns.tv
+at-band-camp.net
+ath.cx
+barrel-of-knowledge.info
+barrell-of-knowledge.info
+better-than.tv
+blogdns.com
+blogdns.net
+blogdns.org
+blogsite.org
+boldlygoingnowhere.org
+broke-it.net
+buyshouses.net
+cechire.com
+dnsalias.com
+dnsalias.net
+dnsalias.org
+dnsdojo.com
+dnsdojo.net
+dnsdojo.org
+does-it.net
+doesntexist.com
+doesntexist.org
+dontexist.com
+dontexist.net
+dontexist.org
+doomdns.com
+doomdns.org
+dvrdns.org
+dyn-o-saur.com
+dynalias.com
+dynalias.net
+dynalias.org
+dynathome.net
+dyndns.ws
+endofinternet.net
+endofinternet.org
+endoftheinternet.org
+est-a-la-maison.com
+est-a-la-masion.com
+est-le-patron.com
+est-mon-blogueur.com
+for-better.biz
+for-more.biz
+for-our.info
+for-some.biz
+for-the.biz
+forgot.her.name
+forgot.his.name
+from-ak.com
+from-al.com
+from-ar.com
+from-az.net
+from-ca.com
+from-co.net
+from-ct.com
+from-dc.com
+from-de.com
+from-fl.com
+from-ga.com
+from-hi.com
+from-ia.com
+from-id.com
+from-il.com
+from-in.com
+from-ks.com
+from-ky.com
+from-la.net
+from-ma.com
+from-md.com
+from-me.org
+from-mi.com
+from-mn.com
+from-mo.com
+from-ms.com
+from-mt.com
+from-nc.com
+from-nd.com
+from-ne.com
+from-nh.com
+from-nj.com
+from-nm.com
+from-nv.com
+from-ny.net
+from-oh.com
+from-ok.com
+from-or.com
+from-pa.com
+from-pr.com
+from-ri.com
+from-sc.com
+from-sd.com
+from-tn.com
+from-tx.com
+from-ut.com
+from-va.com
+from-vt.com
+from-wa.com
+from-wi.com
+from-wv.com
+from-wy.com
+ftpaccess.cc
+fuettertdasnetz.de
+game-host.org
+game-server.cc
+getmyip.com
+gets-it.net
+go.dyndns.org
+gotdns.com
+gotdns.org
+groks-the.info
+groks-this.info
+ham-radio-op.net
+here-for-more.info
+hobby-site.com
+hobby-site.org
+home.dyndns.org
+homedns.org
+homeftp.net
+homeftp.org
+homeip.net
+homelinux.com
+homelinux.net
+homelinux.org
+homeunix.com
+homeunix.net
+homeunix.org
+iamallama.com
+in-the-band.net
+is-a-anarchist.com
+is-a-blogger.com
+is-a-bookkeeper.com
+is-a-bruinsfan.org
+is-a-bulls-fan.com
+is-a-candidate.org
+is-a-caterer.com
+is-a-celticsfan.org
+is-a-chef.com
+is-a-chef.net
+is-a-chef.org
+is-a-conservative.com
+is-a-cpa.com
+is-a-cubicle-slave.com
+is-a-democrat.com
+is-a-designer.com
+is-a-doctor.com
+is-a-financialadvisor.com
+is-a-geek.com
+is-a-geek.net
+is-a-geek.org
+is-a-green.com
+is-a-guru.com
+is-a-hard-worker.com
+is-a-hunter.com
+is-a-knight.org
+is-a-landscaper.com
+is-a-lawyer.com
+is-a-liberal.com
+is-a-libertarian.com
+is-a-linux-user.org
+is-a-llama.com
+is-a-musician.com
+is-a-nascarfan.com
+is-a-nurse.com
+is-a-painter.com
+is-a-patsfan.org
+is-a-personaltrainer.com
+is-a-photographer.com
+is-a-player.com
+is-a-republican.com
+is-a-rockstar.com
+is-a-socialist.com
+is-a-soxfan.org
+is-a-student.com
+is-a-teacher.com
+is-a-techie.com
+is-a-therapist.com
+is-an-accountant.com
+is-an-actor.com
+is-an-actress.com
+is-an-anarchist.com
+is-an-artist.com
+is-an-engineer.com
+is-an-entertainer.com
+is-by.us
+is-certified.com
+is-found.org
+is-gone.com
+is-into-anime.com
+is-into-cars.com
+is-into-cartoons.com
+is-into-games.com
+is-leet.com
+is-lost.org
+is-not-certified.com
+is-saved.org
+is-slick.com
+is-uberleet.com
+is-very-bad.org
+is-very-evil.org
+is-very-good.org
+is-very-nice.org
+is-very-sweet.org
+is-with-theband.com
+isa-geek.com
+isa-geek.net
+isa-geek.org
+isa-hockeynut.com
+issmarterthanyou.com
+isteingeek.de
+istmein.de
+kicks-ass.net
+kicks-ass.org
+knowsitall.info
+land-4-sale.us
+lebtimnetz.de
+leitungsen.de
+likes-pie.com
+likescandy.com
+merseine.nu
+mine.nu
+misconfused.org
+mypets.ws
+myphotos.cc
+neat-url.com
+office-on-the.net
+on-the-web.tv
+podzone.net
+podzone.org
+readmyblog.org
+saves-the-whales.com
+scrapper-site.net
+scrapping.cc
+selfip.biz
+selfip.com
+selfip.info
+selfip.net
+selfip.org
+sells-for-less.com
+sells-for-u.com
+sells-it.net
+sellsyourhome.org
+servebbs.com
+servebbs.net
+servebbs.org
+serveftp.net
+serveftp.org
+servegame.org
+shacknet.nu
+simple-url.com
+space-to-rent.com
+stuff-4-sale.org
+stuff-4-sale.us
+teaches-yoga.com
+thruhere.net
+traeumtgerade.de
+webhop.biz
+webhop.info
+webhop.net
+webhop.org
+worse-than.tv
+writesthisblog.com

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -38,11 +38,11 @@ describe "domain parser" do
     it "includes the scheme" do
       @domain_parser.parse("http://www.pauldix.net")[:scheme].should == "http"
     end
-    
+
     it "includes the full host" do
-      @domain_parser.parse("http://www.pauldix.net")[:host].should == "www.pauldix.net"      
+      @domain_parser.parse("http://www.pauldix.net")[:host].should == "www.pauldix.net"
     end
-    
+
     it "parses out the path" do
       @domain_parser.parse("http://pauldix.net/foo.html?asdf=foo")[:path].should == "/foo.html?asdf=foo"
       @domain_parser.parse("http://pauldix.net?asdf=foo")[:path].should == "?asdf=foo"

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -39,6 +39,11 @@ describe "domain parser" do
       @domain_parser.parse("http://www.pauldix.net")[:scheme].should == "http"
     end
 
+    it "defaults to http if no scheme is applied" do
+      @domain_parser.parse("www.pauldix.net")[:host].should == "www.pauldix.net"
+      @domain_parser.parse("www.pauldix.net")[:scheme].should == "http"
+    end
+
     it "includes the full host" do
       @domain_parser.parse("http://www.pauldix.net")[:host].should == "www.pauldix.net"
     end

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -67,5 +67,12 @@ describe "domain parser" do
       @domain_parser.parse("http://foo.pauldix.net")[:subdomain].should == "foo"
       @domain_parser.parse("http://bar.foo.pauldix.co.uk")[:subdomain].should == "bar.foo"
     end
+    
+    it "should fail gracefully on invalid domain names" do
+      lambda { @domain_parser.parse("http://hello.world") }.should raise_error(Domainatrix::ParseError)
+      lambda { @domain_parser.parse("complete garbage") }.should raise_error(Domainatrix::ParseError)
+      lambda { @domain_parser.parse('') }.should raise_error(Domainatrix::ParseError)
+      lambda { @domain_parser.parse(nil) }.should raise_error(Domainatrix::ParseError)
+    end
   end
 end

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -56,6 +56,7 @@ describe "domain parser" do
       @domain_parser.parse("http://pauldix.com.aichi.jp")[:public_suffix].should == "com.aichi.jp"
       @domain_parser.parse("http://pauldix.السعوديه")[:public_suffix].should == "السعوديه"
       @domain_parser.parse("http://pauldix.臺灣")[:public_suffix].should == "臺灣"
+      @domain_parser.parse("http://www.foo/")[:public_suffix].should == ""
     end
 
     it "should have the domain" do
@@ -72,13 +73,6 @@ describe "domain parser" do
     it "should have subdomains" do
       @domain_parser.parse("http://foo.pauldix.net")[:subdomain].should == "foo"
       @domain_parser.parse("http://bar.foo.pauldix.co.uk")[:subdomain].should == "bar.foo"
-    end
-    
-    it "should fail gracefully on invalid domain names" do
-      lambda { @domain_parser.parse("http://hello.world") }.should raise_error(Domainatrix::ParseError)
-      lambda { @domain_parser.parse("complete garbage") }.should raise_error(Domainatrix::ParseError)
-      lambda { @domain_parser.parse('') }.should raise_error(Domainatrix::ParseError)
-      lambda { @domain_parser.parse(nil) }.should raise_error(Domainatrix::ParseError)
     end
   end
 end

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "domain parser" do
@@ -52,6 +54,8 @@ describe "domain parser" do
       @domain_parser.parse("http://pauldix.co.uk")[:public_suffix].should == "co.uk"
       @domain_parser.parse("http://pauldix.com.kg")[:public_suffix].should == "com.kg"
       @domain_parser.parse("http://pauldix.com.aichi.jp")[:public_suffix].should == "com.aichi.jp"
+      @domain_parser.parse("http://pauldix.السعوديه")[:public_suffix].should == "السعوديه"
+      @domain_parser.parse("http://pauldix.臺灣")[:public_suffix].should == "臺灣"
     end
 
     it "should have the domain" do
@@ -61,6 +65,8 @@ describe "domain parser" do
       @domain_parser.parse("http://foo.pauldix.co.uk")[:domain].should == "pauldix"
       @domain_parser.parse("http://pauldix.com.kg")[:domain].should == "pauldix"
       @domain_parser.parse("http://pauldix.com.aichi.jp")[:domain].should == "pauldix"
+      @domain_parser.parse("http://pauldix.السعوديه")[:domain].should == "pauldix"
+      @domain_parser.parse("http://pauldix.臺灣")[:domain].should == "pauldix"
     end
 
     it "should have subdomains" do

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -63,6 +63,9 @@ describe "url" do
     it "should return false when supplied a malformed url" do
       Domainatrix.parse("bad url").should_not be_valid
       Domainatrix.parse("http://?test.com").should_not be_valid
+      Domainatrix.parse("/test?foo=bar").should_not be_valid
+      Domainatrix.parse("example.com/test?foo=bar").should_not be_valid
+      Domainatrix.parse("www.example.com/test?foo=bar").should_not be_valid
     end
   end
 end

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -51,4 +51,10 @@ describe "url" do
     Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_tld.should == "bar.com"
   end
 
+  describe :valid? do
+    it "should return false without a public suffix" do
+      Domainatrix.parse("http://www.test.com").should be_valid
+      Domainatrix.parse("htpp://www.test.this_is_not_a_public_suffix").should_not be_valid
+    end
+  end
 end

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -64,8 +64,6 @@ describe "url" do
       Domainatrix.parse("bad url").should_not be_valid
       Domainatrix.parse("http://?test.com").should_not be_valid
       Domainatrix.parse("/test?foo=bar").should_not be_valid
-      Domainatrix.parse("example.com/test?foo=bar").should_not be_valid
-      Domainatrix.parse("www.example.com/test?foo=bar").should_not be_valid
     end
   end
 end

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -52,9 +52,17 @@ describe "url" do
   end
 
   describe :valid? do
+    it "should return true when supplied a valid url" do
+      Domainatrix.parse("https://github.com/pauldix/domainatrix/issues/14?foo=bar").should be_valid
+    end
+
     it "should return false without a public suffix" do
-      Domainatrix.parse("http://www.test.com").should be_valid
       Domainatrix.parse("htpp://www.test.this_is_not_a_public_suffix").should_not be_valid
+    end
+
+    it "should return false when supplied a malformed url" do
+      Domainatrix.parse("bad url").should_not be_valid
+      Domainatrix.parse("http://?test.com").should_not be_valid
     end
   end
 end

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -44,7 +44,7 @@ describe "url" do
     Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_public_suffix.should == "foo.co.uk"
     Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_public_suffix.should == "bar.com"
   end
-  
+
   it "combines the domain with the public_suffix as an alias" do
     Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_tld.should == "pauldix.net"
     Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_tld.should == "foo.co.uk"

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -15,17 +15,17 @@ describe "domainatrix" do
     Domainatrix.parse("http://foo.bar.pauldix.net").canonical.should == "net.pauldix.bar.foo"
     Domainatrix.parse("http://pauldix.co.uk").canonical.should == "uk.co.pauldix"
   end
-  
+
   it "should canonicalize extended utf-8 tlds" do
     Domainatrix.parse("http://pauldix.臺灣").canonical.should == "臺灣.pauldix"
     Domainatrix.parse("http://pauldix.السعوديه").canonical.should == "السعوديه.pauldix"
   end
-  
+
   it "should not canonicalize invalid domain names" do
-    Domainatrix.parse("http://hello.world").should be_nil
-    Domainatrix.parse("http://helloworld").should be_nil
+    Domainatrix.parse("http://hello.world").canonical.should be_nil
+    Domainatrix.parse("http://helloworld").canonical.should be_nil
   end
-  
+
   it "should accept custom tlds" do
     Domainatrix.recognize_tld("foo").should == ['foo']
     Domainatrix.parse("http://pauldix.foo").should be_a Domainatrix::Url

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe "domainatrix" do
@@ -12,6 +14,11 @@ describe "domainatrix" do
     Domainatrix.parse("http://foo.pauldix.net").canonical.should == "net.pauldix.foo"
     Domainatrix.parse("http://foo.bar.pauldix.net").canonical.should == "net.pauldix.bar.foo"
     Domainatrix.parse("http://pauldix.co.uk").canonical.should == "uk.co.pauldix"
+  end
+  
+  it "should canonicalize extended utf-8 tlds" do
+    Domainatrix.parse("http://pauldix.臺灣").canonical.should == "臺灣.pauldix"
+    Domainatrix.parse("http://pauldix.السعوديه").canonical.should == "السعوديه.pauldix"
   end
   
   it "should not canonicalize invalid domain names" do

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -13,4 +13,10 @@ describe "domainatrix" do
     Domainatrix.parse("http://foo.bar.pauldix.net").canonical.should == "net.pauldix.bar.foo"
     Domainatrix.parse("http://pauldix.co.uk").canonical.should == "uk.co.pauldix"
   end
+  
+  it "should accept custom tlds" do
+    Domainatrix.recognize_tld("foo").should == ['foo']
+    Domainatrix.parse("http://pauldix.foo").should be_a Domainatrix::Url
+    Domainatrix.parse("http://pauldix.foo").canonical.should == "foo.pauldix"
+  end
 end

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -14,6 +14,11 @@ describe "domainatrix" do
     Domainatrix.parse("http://pauldix.co.uk").canonical.should == "uk.co.pauldix"
   end
   
+  it "should not canonicalize invalid domain names" do
+    Domainatrix.parse("http://hello.world").should be_nil
+    Domainatrix.parse("http://helloworld").should be_nil
+  end
+  
   it "should accept custom tlds" do
     Domainatrix.recognize_tld("foo").should == ['foo']
     Domainatrix.parse("http://pauldix.foo").should be_a Domainatrix::Url


### PR DESCRIPTION
Split up a large method into smaller methods.
Simplified conditions.
Removed white space.
Domains with no public suffixes now return a empty string as the public_suffix value instead of raising errors. (Requested by issue #16)
Added a valid? method to the URL class. (Requested by issue #14)
Tested against issue #15.
Rescued against Addressable::URI::InvalidURIError exception.
Defaults to http scheme. #13.

Includes a couple other refactors, see diff.

99.25% test coverage. Took simplecov warnings from 16 to 10.

Rebased on Jamie Cobbett's 0.0.10 version of the gem.

Bumped version to 0.0.11 after covering issue #16.
Bumped version to 0.0.12 after covering issue #14.

Cheers.
