### PR TITLE
url port support added

### DIFF
--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -50,7 +50,8 @@ module Domainatrix
         :scheme => uri.scheme,
         :host   => uri.host,
         :path   => path,
-        :url    => url
+        :url    => url,
+        :port   => uri.port || 80
       })
     end
 

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -1,6 +1,6 @@
 module Domainatrix
   class Url
-    attr_reader :public_suffix, :domain, :subdomain, :path, :url, :scheme, :host
+    attr_reader :public_suffix, :domain, :subdomain, :path, :url, :scheme, :host, :port
 
     def initialize(attrs = {})
       @scheme = attrs[:scheme] || ''
@@ -10,6 +10,7 @@ module Domainatrix
       @domain = attrs[:domain] || ''
       @subdomain = attrs[:subdomain] || ''
       @path = attrs[:path] || ''
+      @port = attrs[:port]
     end
 
     def canonical(options = {})
@@ -19,6 +20,7 @@ module Domainatrix
         subdomain_parts = @subdomain.split(".")
         url << ".#{subdomain_parts.reverse.join(".")}"
       end
+      url << ":#{@port}" if @port && @port != 80
       url << @path if @path
 
       url

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -41,6 +41,11 @@ describe "domain parser" do
       @domain_parser.parse("http://www.pauldix.net")[:host].should == "www.pauldix.net"      
     end
     
+    it "includes the original port" do
+      @domain_parser.parse("http://www.pauldix.net")[:port].should == 80
+      @domain_parser.parse("http://www.pauldix.net:8000")[:port].should == 8000
+    end
+
     it "parses out the path" do
       @domain_parser.parse("http://pauldix.net/foo.html?asdf=foo")[:path].should == "/foo.html?asdf=foo"
       @domain_parser.parse("http://pauldix.net?asdf=foo")[:path].should == "?asdf=foo"

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -21,34 +21,87 @@ describe "url" do
     Domainatrix::Url.new(:path => "/asdf.html").path.should == "/asdf.html"
   end
 
+  it "has the port" do
+    Domainatrix::Url.new(:port => 8000).port.should == 8000
+  end
+
+  def should_canonicalize_url_for_port(given_port = nil, resulting_port = nil)
+    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net", :port => given_port).canonical.should == "net.pauldix#{resulting_port}"
+    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :port => given_port).canonical.should == "net.pauldix.foo#{resulting_port}"
+    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "net", :port => given_port).canonical.should == "net.pauldix.bar.foo#{resulting_port}"
+    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "co.uk", :port => given_port).canonical.should == "uk.co.pauldix#{resulting_port}"
+    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "co.uk", :port => given_port).canonical.should == "uk.co.pauldix.foo#{resulting_port}"
+    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "co.uk", :port => given_port).canonical.should == "uk.co.pauldix.bar.foo#{resulting_port}"
+    Domainatrix::Url.new(:subdomain => "", :domain => "pauldix", :public_suffix => "co.uk", :port => given_port).canonical.should == "uk.co.pauldix#{resulting_port}"
+  end
+
+  def should_canonicalize_url_without_port
+    should_canonicalize_url_for_port
+  end
+
   it "canonicalizes the url" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix"
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix.foo"
-    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix.bar.foo"
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix"
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix.foo"
-    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix.bar.foo"
-    Domainatrix::Url.new(:subdomain => "", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix"
+    should_canonicalize_url_without_port
+    should_canonicalize_url_for_port 80
+    should_canonicalize_url_for_port 8000, ":8000"
+  end
+
+  def should_canonicalize_url_with_path_for_port(given_port = nil, resulting_port = nil)
+    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :path => "/hello", :port => given_port).canonical.should == "net.pauldix.foo#{resulting_port}/hello"
+  end
+
+  def should_canonicalize_url_with_path_without_port
+    should_canonicalize_url_with_path_for_port
   end
 
   it "canonicalizes the url with the path" do
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :path => "/hello").canonical.should == "net.pauldix.foo/hello"
+    should_canonicalize_url_with_path_without_port
+    should_canonicalize_url_with_path_for_port 80
+    should_canonicalize_url_with_path_for_port 8000, ":8000"
+  end
+
+  def should_canonicalize_url_without_path_for_port(given_port = nil, resulting_port = nil)
+    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :port => given_port).canonical(:include_path => false).should == "net.pauldix.foo#{resulting_port}"
+  end
+
+  def should_canonicalize_url_without_path_without_port
+    should_canonicalize_url_with_path_for_port
   end
 
   it "canonicalizes the url without the path" do
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical(:include_path => false).should == "net.pauldix.foo"
+    should_canonicalize_url_without_path_without_port
+    should_canonicalize_url_without_path_for_port 80
+    should_canonicalize_url_without_path_for_port 8000, ":8000"
+  end
+
+  def should_combine_domain_with_public_suffix_for_port(given_port = nil)
+    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net", :port => given_port).domain_with_public_suffix.should == "pauldix.net"
+    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk", :port => given_port).domain_with_public_suffix.should == "foo.co.uk"
+    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com", :port => given_port).domain_with_public_suffix.should == "bar.com"
+  end
+
+  def should_combine_domain_with_public_suffix_without_port
+    should_combine_domain_with_public_suffix_for_port
   end
 
   it "combines the domain with the public_suffix" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_public_suffix.should == "pauldix.net"
-    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_public_suffix.should == "foo.co.uk"
-    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_public_suffix.should == "bar.com"
-  end
-  
-  it "combines the domain with the public_suffix as an alias" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_tld.should == "pauldix.net"
-    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_tld.should == "foo.co.uk"
-    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_tld.should == "bar.com"
+    should_combine_domain_with_public_suffix_without_port
+    should_combine_domain_with_public_suffix_for_port 80
+    should_combine_domain_with_public_suffix_for_port 8000
   end
 
+  def should_combine_domain_with_public_suffix_as_an_alias_for_port(given_port = nil)
+    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net", :port => given_port).domain_with_tld.should == "pauldix.net"
+    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk", :port => given_port).domain_with_tld.should == "foo.co.uk"
+    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com", :port => given_port).domain_with_tld.should == "bar.com"
+  end
+
+  def should_combine_domain_with_public_suffix_as_an_alias_without_port
+    should_combine_domain_with_public_suffix_as_an_alias_for_port
+  end
+
+  it "combines the domain with the public_suffix as an alias" do
+    should_combine_domain_with_public_suffix_as_an_alias_without_port
+    should_combine_domain_with_public_suffix_as_an_alias_for_port 80
+    should_combine_domain_with_public_suffix_as_an_alias_for_port 8000
+  end
 end

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -24,6 +24,7 @@ describe "domainatrix" do
     its(:subdomain) { should == '' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == 'localhost' }
+    its(:port) { should == 3000 }
   end
 
   context 'without a scheme' do
@@ -36,6 +37,7 @@ describe "domainatrix" do
     its(:subdomain) { should == 'www' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == 'pauldix.net' }
+    its(:port) { should == 80 }
   end
 
   context 'with a blank url' do
@@ -48,6 +50,6 @@ describe "domainatrix" do
     its(:subdomain) { should == '' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == '' }
+    its(:port) { should == nil }
   end
-
 end


### PR DESCRIPTION
Hi,

In one project I needed the port to be compared too so I added the needed support.
Currently port is extracted/canonicalized from url by default (if present and != 80), but that can be changed.

The specs have been updated to reflect this change.
Not entirely happy with url_spec, maybe there is no need to add port variations to all the test, please have a look and let me know if there is something you don't like.
I didn't update the gem version.

Hope you find this useful.
And thanks for the gem :-)
