### PR TITLE
Include original parsed uri

### DIFF
--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{domainatrix}
-  s.version = "0.0.11"
+  s.version = "0.0.12"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Paul Dix", "Brian John"]

--- a/lib/domainatrix/domain_parser.rb
+++ b/lib/domainatrix/domain_parser.rb
@@ -52,11 +52,12 @@ module Domainatrix
       end
 
       uri_hash.merge({
-        :scheme => uri.scheme,
-        :host   => uri.host,
-        :port   => (uri.port == uri.default_port) ? nil : uri.port,
-        :path   => path,
-        :url    => url
+        :scheme     => uri.scheme,
+        :host       => uri.host,
+        :port       => (uri.port == uri.default_port) ? nil : uri.port,
+        :path       => path,
+        :url        => url,
+        :parsed_uri => uri
       })
     end
 

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -1,6 +1,6 @@
 module Domainatrix
   class Url
-    attr_reader :public_suffix, :domain, :subdomain, :path, :url, :scheme, :host, :port
+    attr_reader :public_suffix, :domain, :subdomain, :path, :url, :scheme, :host, :port, :parsed_uri
 
     def initialize(attrs = {})
       @scheme = attrs[:scheme] || ''
@@ -13,6 +13,7 @@ module Domainatrix
       @path = attrs[:path] || ''
       @localhost = (attrs[:localhost] == true)
       @ip = (attrs[:ip] == true)
+      @parsed_uri = attrs[:parsed_uri] || ''
     end
 
     def canonical(options = {})

--- a/lib/domainatrix/url.rb
+++ b/lib/domainatrix/url.rb
@@ -1,5 +1,6 @@
 module Domainatrix
   class Url
+    include Addressable
     attr_reader :public_suffix, :domain, :subdomain, :path, :url, :scheme, :host, :port, :parsed_uri
 
     def initialize(attrs = {})
@@ -13,7 +14,7 @@ module Domainatrix
       @path = attrs[:path] || ''
       @localhost = (attrs[:localhost] == true)
       @ip = (attrs[:ip] == true)
-      @parsed_uri = attrs[:parsed_uri] || ''
+      @parsed_uri = attrs[:parsed_uri] || URI.parse('')
     end
 
     def canonical(options = {})

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -67,5 +67,10 @@ describe "domain parser" do
       @domain_parser.parse("http://foo.pauldix.net")[:subdomain].should == "foo"
       @domain_parser.parse("http://bar.foo.pauldix.co.uk")[:subdomain].should == "bar.foo"
     end
+    
+    it "should have original uri" do
+      @domain_parser.parse("http://foo.pauldix.net")[:parsed_uri].hostname.should == "foo.pauldix.net"
+      @domain_parser.parse("http://bar.foo.pauldix.co.uk")[:parsed_uri].hostname.should == "bar.foo.pauldix.co.uk"
+    end
   end
 end

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -24,6 +24,7 @@ describe "domainatrix" do
     its(:subdomain) { should == '' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == 'localhost' }
+    its('parsed_uri.hostname') { should == 'localhost' }
   end
 
   context 'without a scheme' do
@@ -36,6 +37,7 @@ describe "domainatrix" do
     its(:subdomain) { should == 'www' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == 'pauldix.net' }
+    its('parsed_uri.hostname') { should == 'www.pauldix.net' }
   end
 
   context 'with a blank url' do
@@ -48,6 +50,7 @@ describe "domainatrix" do
     its(:subdomain) { should == '' }
     its(:path) { should == '' }
     its(:domain_with_tld) { should == '' }
+    its('parsed_uri.hostname') { should be_nil }
   end
 
 end


### PR DESCRIPTION
I love this gem but I noticed I was always trying to get the query separate from the path. I noticed that the gem is using the URI to parse. I have included the original parsed URI object on the DomainParser. This way the users can utilize your code for the domain and sub domain stuff that does not exist in URI parser and still have access to the original parsed url the includes fragment, query and original path. 
