### PR TITLE
Updates outdated dependecies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       addressable
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.3.3)
     archive-tar-minitar (0.5.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,20 +10,23 @@ GEM
     addressable (2.3.3)
     archive-tar-minitar (0.5.2)
     columnize (0.3.4)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)
       ruby_core_source (>= 0.1.4)
     rbx-require-relative (0.0.5)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.1)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-mocks (2.99.2)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
       ruby-debug-base (~> 0.10.4.0)
@@ -45,6 +48,7 @@ PLATFORMS
 
 DEPENDENCIES
   domainatrix!
-  rspec
+  rspec (~> 2.0)
+  rspec-its (~> 1.0)
   ruby-debug
   ruby-debug19

--- a/domainatrix.gemspec
+++ b/domainatrix.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.5}
   s.summary = %q{A cruel mistress that uses the public suffix domain list to dominate URLs by canonicalizing, finding the public suffix, and breaking them into their domain parts.}
   s.add_dependency("addressable")
-  s.add_development_dependency("rspec")
+  s.add_development_dependency("rspec", "~> 2.0")
+  s.add_development_dependency("rspec-its", "~> 1.0")
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION

--- a/spec/domainatrix/domain_parser_spec.rb
+++ b/spec/domainatrix/domain_parser_spec.rb
@@ -7,65 +7,65 @@ describe "domain parser" do
 
   describe "reading the dat file" do
     it "creates a tree of the domain names" do
-      @domain_parser.public_suffixes.should be_a Hash
+      expect(@domain_parser.public_suffixes).to be_a Hash
     end
 
     it "creates the first level of the tree" do
-      @domain_parser.public_suffixes.should have_key("com")
+      expect(@domain_parser.public_suffixes).to have_key("com")
     end
 
     it "creates the first level of the tree even when the first doesn't appear on a line by itself" do
-      @domain_parser.public_suffixes.should have_key("uk")
+      expect(@domain_parser.public_suffixes).to have_key("uk")
     end
 
     it "creates lower levels of the tree" do
-      @domain_parser.public_suffixes["jp"].should have_key("ac")
-      @domain_parser.public_suffixes["jp"]["kawasaki"].should have_key("*")
+      expect(@domain_parser.public_suffixes["jp"]).to have_key("ac")
+      expect(@domain_parser.public_suffixes["jp"]["kawasaki"]).to have_key("*")
     end
   end
 
   describe "parsing" do
     it "returns a hash of parts" do
-      @domain_parser.parse("http://pauldix.net").should be_a Hash
+      expect(@domain_parser.parse("http://pauldix.net")).to be_a Hash
     end
 
     it "includes the original url" do
-      @domain_parser.parse("http://www.pauldix.net")[:url].should == "http://www.pauldix.net"
+      expect(@domain_parser.parse("http://www.pauldix.net")[:url]).to eq("http://www.pauldix.net")
     end
 
     it "includes the scheme" do
-      @domain_parser.parse("http://www.pauldix.net")[:scheme].should == "http"
+      expect(@domain_parser.parse("http://www.pauldix.net")[:scheme]).to eq("http")
     end
     
     it "includes the full host" do
-      @domain_parser.parse("http://www.pauldix.net")[:host].should == "www.pauldix.net"      
+      expect(@domain_parser.parse("http://www.pauldix.net")[:host]).to eq("www.pauldix.net")      
     end
     
     it "parses out the path" do
-      @domain_parser.parse("http://pauldix.net/foo.html?asdf=foo")[:path].should == "/foo.html?asdf=foo"
-      @domain_parser.parse("http://pauldix.net?asdf=foo")[:path].should == "?asdf=foo"
-      @domain_parser.parse("http://pauldix.net")[:path].should == ""
+      expect(@domain_parser.parse("http://pauldix.net/foo.html?asdf=foo")[:path]).to eq("/foo.html?asdf=foo")
+      expect(@domain_parser.parse("http://pauldix.net?asdf=foo")[:path]).to eq("?asdf=foo")
+      expect(@domain_parser.parse("http://pauldix.net")[:path]).to eq("")
     end
 
     it "parses the tld" do
-      @domain_parser.parse("http://pauldix.net")[:public_suffix].should == "net"
-      @domain_parser.parse("http://pauldix.co.uk")[:public_suffix].should == "co.uk"
-      @domain_parser.parse("http://pauldix.com.kg")[:public_suffix].should == "com.kg"
-      @domain_parser.parse("http://pauldix.com.kawasaki.jp")[:public_suffix].should == "com.kawasaki.jp"
+      expect(@domain_parser.parse("http://pauldix.net")[:public_suffix]).to eq("net")
+      expect(@domain_parser.parse("http://pauldix.co.uk")[:public_suffix]).to eq("co.uk")
+      expect(@domain_parser.parse("http://pauldix.com.kg")[:public_suffix]).to eq("com.kg")
+      expect(@domain_parser.parse("http://pauldix.com.kawasaki.jp")[:public_suffix]).to eq("com.kawasaki.jp")
     end
 
     it "should have the domain" do
-      @domain_parser.parse("http://pauldix.net")[:domain].should == "pauldix"
-      @domain_parser.parse("http://foo.pauldix.net")[:domain].should == "pauldix"
-      @domain_parser.parse("http://pauldix.co.uk")[:domain].should == "pauldix"
-      @domain_parser.parse("http://foo.pauldix.co.uk")[:domain].should == "pauldix"
-      @domain_parser.parse("http://pauldix.com.kg")[:domain].should == "pauldix"
-      @domain_parser.parse("http://pauldix.com.kawasaki.jp")[:domain].should == "pauldix"
+      expect(@domain_parser.parse("http://pauldix.net")[:domain]).to eq("pauldix")
+      expect(@domain_parser.parse("http://foo.pauldix.net")[:domain]).to eq("pauldix")
+      expect(@domain_parser.parse("http://pauldix.co.uk")[:domain]).to eq("pauldix")
+      expect(@domain_parser.parse("http://foo.pauldix.co.uk")[:domain]).to eq("pauldix")
+      expect(@domain_parser.parse("http://pauldix.com.kg")[:domain]).to eq("pauldix")
+      expect(@domain_parser.parse("http://pauldix.com.kawasaki.jp")[:domain]).to eq("pauldix")
     end
 
     it "should have subdomains" do
-      @domain_parser.parse("http://foo.pauldix.net")[:subdomain].should == "foo"
-      @domain_parser.parse("http://bar.foo.pauldix.co.uk")[:subdomain].should == "bar.foo"
+      expect(@domain_parser.parse("http://foo.pauldix.net")[:subdomain]).to eq("foo")
+      expect(@domain_parser.parse("http://bar.foo.pauldix.co.uk")[:subdomain]).to eq("bar.foo")
     end
   end
 end

--- a/spec/domainatrix/url_spec.rb
+++ b/spec/domainatrix/url_spec.rb
@@ -2,53 +2,53 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe "url" do
   it "has the original url" do
-    Domainatrix::Url.new(:url => "http://pauldix.net").url.should == "http://pauldix.net"
+    expect(Domainatrix::Url.new(:url => "http://pauldix.net").url).to eq("http://pauldix.net")
   end
 
   it "has the public_suffix" do
-    Domainatrix::Url.new(:public_suffix => "net").public_suffix.should == "net"
+    expect(Domainatrix::Url.new(:public_suffix => "net").public_suffix).to eq("net")
   end
 
   it "has the domain" do
-    Domainatrix::Url.new(:domain => "pauldix").domain.should == "pauldix"
+    expect(Domainatrix::Url.new(:domain => "pauldix").domain).to eq("pauldix")
   end
 
   it "has the subdomain" do
-    Domainatrix::Url.new(:subdomain => "foo").subdomain.should == "foo"
+    expect(Domainatrix::Url.new(:subdomain => "foo").subdomain).to eq("foo")
   end
 
   it "has the path" do
-    Domainatrix::Url.new(:path => "/asdf.html").path.should == "/asdf.html"
+    expect(Domainatrix::Url.new(:path => "/asdf.html").path).to eq("/asdf.html")
   end
 
   it "canonicalizes the url" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix"
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix.foo"
-    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "net").canonical.should == "net.pauldix.bar.foo"
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix"
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix.foo"
-    Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix.bar.foo"
-    Domainatrix::Url.new(:subdomain => "", :domain => "pauldix", :public_suffix => "co.uk").canonical.should == "uk.co.pauldix"
+    expect(Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").canonical).to eq("net.pauldix")
+    expect(Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical).to eq("net.pauldix.foo")
+    expect(Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "net").canonical).to eq("net.pauldix.bar.foo")
+    expect(Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "co.uk").canonical).to eq("uk.co.pauldix")
+    expect(Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "co.uk").canonical).to eq("uk.co.pauldix.foo")
+    expect(Domainatrix::Url.new(:subdomain => "foo.bar", :domain => "pauldix", :public_suffix => "co.uk").canonical).to eq("uk.co.pauldix.bar.foo")
+    expect(Domainatrix::Url.new(:subdomain => "", :domain => "pauldix", :public_suffix => "co.uk").canonical).to eq("uk.co.pauldix")
   end
 
   it "canonicalizes the url with the path" do
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :path => "/hello").canonical.should == "net.pauldix.foo/hello"
+    expect(Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net", :path => "/hello").canonical).to eq("net.pauldix.foo/hello")
   end
 
   it "canonicalizes the url without the path" do
-    Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical(:include_path => false).should == "net.pauldix.foo"
+    expect(Domainatrix::Url.new(:subdomain => "foo", :domain => "pauldix", :public_suffix => "net").canonical(:include_path => false)).to eq("net.pauldix.foo")
   end
 
   it "combines the domain with the public_suffix" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_public_suffix.should == "pauldix.net"
-    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_public_suffix.should == "foo.co.uk"
-    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_public_suffix.should == "bar.com"
+    expect(Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_public_suffix).to eq("pauldix.net")
+    expect(Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_public_suffix).to eq("foo.co.uk")
+    expect(Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_public_suffix).to eq("bar.com")
   end
   
   it "combines the domain with the public_suffix as an alias" do
-    Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_tld.should == "pauldix.net"
-    Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_tld.should == "foo.co.uk"
-    Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_tld.should == "bar.com"
+    expect(Domainatrix::Url.new(:domain => "pauldix", :public_suffix => "net").domain_with_tld).to eq("pauldix.net")
+    expect(Domainatrix::Url.new(:domain => "foo", :public_suffix => "co.uk" ).domain_with_tld).to eq("foo.co.uk")
+    expect(Domainatrix::Url.new(:subdomain => "baz", :domain => "bar", :public_suffix => "com").domain_with_tld).to eq("bar.com")
   end
 
 end

--- a/spec/domainatrix_spec.rb
+++ b/spec/domainatrix_spec.rb
@@ -2,16 +2,16 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe "domainatrix" do
   it "should parse into a url object" do
-    Domainatrix.parse("http://pauldix.net").should be_a Domainatrix::Url
+    expect(Domainatrix.parse("http://pauldix.net")).to be_a Domainatrix::Url
   end
 
   it "should canonicalize" do
-    Domainatrix.parse("http://pauldix.net").canonical.should == "net.pauldix"
-    Domainatrix.parse("http://pauldix.net/foo.html").canonical.should == "net.pauldix/foo.html"
-    Domainatrix.parse("http://pauldix.net/foo.html?asdf=bar").canonical.should == "net.pauldix/foo.html?asdf=bar"
-    Domainatrix.parse("http://foo.pauldix.net").canonical.should == "net.pauldix.foo"
-    Domainatrix.parse("http://foo.bar.pauldix.net").canonical.should == "net.pauldix.bar.foo"
-    Domainatrix.parse("http://pauldix.co.uk").canonical.should == "uk.co.pauldix"
+    expect(Domainatrix.parse("http://pauldix.net").canonical).to eq("net.pauldix")
+    expect(Domainatrix.parse("http://pauldix.net/foo.html").canonical).to eq("net.pauldix/foo.html")
+    expect(Domainatrix.parse("http://pauldix.net/foo.html?asdf=bar").canonical).to eq("net.pauldix/foo.html?asdf=bar")
+    expect(Domainatrix.parse("http://foo.pauldix.net").canonical).to eq("net.pauldix.foo")
+    expect(Domainatrix.parse("http://foo.bar.pauldix.net").canonical).to eq("net.pauldix.bar.foo")
+    expect(Domainatrix.parse("http://pauldix.co.uk").canonical).to eq("uk.co.pauldix")
   end
 
   context 'localhost with a port' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "rubygems"
 require "rspec"
+require "rspec/its"
 
 # gem install redgreen for colored test output
 begin require "redgreen" unless ENV['TM_CURRENT_LINE']; rescue LoadError; end


### PR DESCRIPTION
- Use https://rubygems.org as gems source …
  To get rid of the following deprecation warning:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org'; if possible, or 'http://rubygems.org'; if not.
```
- Bump RSpec version and add rspec-its …
  RSpec needed to be upgraded to void getting this error when installing the dependencies:

```
An error occurred while installing rspec-expectations (2.7.0), and Bundler cannot continue.
Make sure that `gem install rspec-expectations -v '2.7.0'` succeeds before bundling.
```

Adding rspec-it was necessary since rpsec -v2.99.x extracted `its {}` type of assertion in the process of migrating to Rspec 3.
- Convert specs to RSpec 2.99.1 syntax. Gets rid of every deprecation warning.
